### PR TITLE
Fix > Steampipe > Cloudflare > plugin Title

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,11 +6,11 @@ brand_color: "#f48120"
 display_name: Cloudflare
 name: cloudflare
 description: Steampipe plugin for querying Cloudflare databases, networks, and other resources.
-og_description: Query cloudflare databases, networks, and other resources with SQL! Open source CLI. No DB required. 
+og_description: Query cloudflare databases, networks, and other resources with SQL! Open source CLI. No DB required.
 og_image: "/images/plugins/turbot/cloudflare-social-graphic.png"
 ---
 
-# Cloudflare
+# Cloudflare + Steampipe
 
 Query your Cloudflare infrastructure including zones, DNS records, accounts and more.
 


### PR DESCRIPTION
Making a small change to the title of the plugin by adding `+ Steampipe` to it that was missing.