### PR TITLE
Add table `cloudflare_zone_setting` and deprecated the column `settings` from the table `cloudflare_zone` Closes #169

### DIFF
--- a/cloudflare/plugin.go
+++ b/cloudflare/plugin.go
@@ -42,6 +42,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"cloudflare_user_audit_log":        tableCloudflareUserAuditLog(ctx),
 			"cloudflare_worker_route":          tableCloudflareWorkerRoute(ctx),
 			"cloudflare_zone":                  tableCloudflareZone(ctx),
+			"cloudflare_zone_setting":          tableCloudflareZoneSetting(ctx),
 		},
 	}
 	return p

--- a/cloudflare/table_cloudflare_zone.go
+++ b/cloudflare/table_cloudflare_zone.go
@@ -2,7 +2,6 @@ package cloudflare
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cloudflare/cloudflare-go/v4"
 	"github.com/cloudflare/cloudflare-go/v4/dns"
@@ -43,7 +42,7 @@ func tableCloudflareZone(ctx context.Context) *plugin.Table {
 			{Name: "owner", Type: proto.ColumnType_JSON, Description: "Information about the user or organization that owns the zone."},
 			{Name: "paused", Type: proto.ColumnType_BOOL, Description: "Indicates if the zone is only using Cloudflare DNS services. A true value means the zone will not receive security or performance benefits."},
 			{Name: "permissions", Type: proto.ColumnType_JSON, Description: "Available permissions on the zone for the current user requesting the item.", Transform: transform.FromP(getExtraFieldPermissionsFromAPIresponse, "permissions")},
-			{Name: "settings", Type: proto.ColumnType_JSON, Hydrate: getZoneSettings, Transform: transform.FromValue().Transform(settingsToStandard), Description: "Simple key value map of zone settings like advanced_ddos = on."},
+			{Name: "settings", Type: proto.ColumnType_JSON, Description: "[DEPRECATED] Simple key value map of zone settings like advanced_ddos = on. Use cloudflare_zone_setting table instead."},
 			{Name: "plan", Type: proto.ColumnType_JSON, Hydrate: getZonePlan, Transform: transform.FromValue(), Description: "Current plan associated with the zone."},
 			{Name: "plan_pending", Type: proto.ColumnType_JSON, Description: "[DEPRECATED] Pending plan change associated with the zone."},
 			{Name: "status", Type: proto.ColumnType_STRING, Description: "Status of the zone."},
@@ -108,44 +107,6 @@ func getZone(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (i
 		return nil, err
 	}
 	return &zone, nil
-}
-
-func getZoneSettings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	conn, err := connectV4(ctx, d)
-	if err != nil {
-		return nil, err
-	}
-
-	zone := h.Item.(zones.Zone)
-	// valid setting "aegis"?
-	settingIds := []string{"0rtt", "advanced_ddos", "always_online", "always_use_https", "automatic_https_rewrites", "brotli", "browser_cache_ttl", "browser_check", "cache_level", "challenge_ttl", "ciphers", "cname_flattening", "development_mode", "early_hints", "edge_cache_ttl", "email_obfuscation", "h2_prioritization", "hotlink_protection", "http2", "http3", "image_resizing", "ip_geolocation", "ipv6", "max_upload", "min_tls_version", "mirage", "nel", "opportunistic_encryption", "opportunistic_onion", "orange_to_orange", "origin_error_page_pass_thru", "origin_h2_max_streams", "origin_max_http_version", "polish", "prefetch_preload", "privacy_pass", "proxy_read_timeout", "pseudo_ipv4", "replace_insecure_js", "response_buffering", "rocket_loader", "automatic_platform_optimization", "security_header", "security_level", "server_side_exclude", "sha1_support", "sort_query_string_for_cache", "ssl", "ssl_recommender", "tls_1_2_only", "tls_1_3", "tls_client_auth", "true_client_ip_header", "waf", "webp", "websockets"}
-	settings := []zones.SettingGetResponse{}
-
-	for _, settingId := range settingIds {
-		item, err := conn.Zones.Settings.Get(ctx, settingId, zones.SettingGetParams{ZoneID: cloudflare.F(zone.ID)})
-		if err != nil {
-			// All of the setting could not be retrieved
-			if strings.Contains(err.Error(), "Undefined zone setting") {
-				continue
-			}
-			if strings.Contains(err.Error(), "Access denied") {
-				return nil, nil
-			}
-			return nil, err
-		}
-		settings = append(settings, *item)
-	}
-
-	return settings, nil
-}
-
-func settingsToStandard(_ context.Context, d *transform.TransformData) (interface{}, error) {
-	settings := d.HydrateItem.([]zones.SettingGetResponse)
-	settingsMap := map[string]interface{}{}
-	for _, i := range settings {
-		settingsMap[string(i.ID)] = i.Value
-	}
-	return settingsMap, nil
 }
 
 func getZoneDNSSEC(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/cloudflare/table_cloudflare_zone_setting.go
+++ b/cloudflare/table_cloudflare_zone_setting.go
@@ -1,0 +1,138 @@
+package cloudflare
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go/v4"
+	"github.com/cloudflare/cloudflare-go/v4/zones"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+const matrixKeySetting = "setting_id"
+
+// BuildZoneSettingMatrix :: return a list of matrix items, one per setting ID.
+// This allows us to query each zone setting individually.
+func BuildZoneSettingMatrix(ctx context.Context, d *plugin.QueryData) []map[string]interface{} {
+	// cache matrix
+	cacheKey := "ZoneSettingMatrix"
+	if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
+		return cachedData.([]map[string]interface{})
+	}
+
+	// Available zone setting IDs
+	settingIds := []string{
+		"0rtt", "advanced_ddos", "always_online", "always_use_https", "automatic_https_rewrites",
+		"brotli", "browser_cache_ttl", "browser_check", "cache_level", "challenge_ttl",
+		"ciphers", "cname_flattening", "development_mode", "early_hints", "edge_cache_ttl",
+		"email_obfuscation", "h2_prioritization", "hotlink_protection", "http2", "http3",
+		"image_resizing", "ip_geolocation", "ipv6", "max_upload", "min_tls_version",
+		"mirage", "nel", "opportunistic_encryption", "opportunistic_onion", "orange_to_orange",
+		"origin_error_page_pass_thru", "origin_h2_max_streams", "origin_max_http_version",
+		"polish", "prefetch_preload", "privacy_pass", "proxy_read_timeout", "pseudo_ipv4",
+		"replace_insecure_js", "response_buffering", "rocket_loader", "automatic_platform_optimization",
+		"security_header", "security_level", "server_side_exclude", "sha1_support",
+		"sort_query_string_for_cache", "ssl", "ssl_recommender", "tls_1_2_only", "tls_1_3",
+		"tls_client_auth", "true_client_ip_header", "waf", "webp", "websockets",
+	}
+
+	matrix := make([]map[string]interface{}, len(settingIds))
+	for i, settingId := range settingIds {
+		matrix[i] = map[string]interface{}{matrixKeySetting: settingId}
+	}
+
+	// set cache
+	d.ConnectionManager.Cache.Set(cacheKey, matrix)
+	return matrix
+}
+
+func tableCloudflareZoneSetting(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "cloudflare_zone_setting",
+		Description: "Individual zone settings that control various Cloudflare features for a zone.",
+		List: &plugin.ListConfig{
+			Hydrate:       listZoneSettings,
+			ParentHydrate: listZones,
+			KeyColumns: plugin.KeyColumnSlice{
+				{Name: "zone_id", Require: plugin.Optional},
+				{Name: "id", Require: plugin.Optional},
+			},
+		},
+		GetMatrixItemFunc: BuildZoneSettingMatrix,
+		Columns: commonColumns([]*plugin.Column{
+			// Top columns
+			{Name: "id", Type: proto.ColumnType_STRING, Transform: transform.FromField("ID"), Description: "The ID of the zone setting."},
+			{Name: "zone_id", Type: proto.ColumnType_STRING, Transform: transform.FromField("ZoneID"), Description: "Zone identifier."},
+
+			// The value field from the API response may have string or JSON property.
+			// for couple of settings like security_header, automatic_platform_optimization, ciphers, etc... we will have JSON value
+			// rest are string, integer type.
+			// So we have set the data type as string
+			{Name: "value", Type: proto.ColumnType_STRING, Description: "The current value of the zone setting."},
+
+			// Other columns
+			{Name: "editable", Type: proto.ColumnType_BOOL, Transform: transform.From(transformEditable), Description: "Whether the setting is editable."},
+			{Name: "enabled", Type: proto.ColumnType_BOOL, Description: "SSL-recommender enrollment setting."},
+			{Name: "modified_on", Type: proto.ColumnType_TIMESTAMP, Description: "When the setting was last modified."},
+		}),
+	}
+}
+
+type ZoneSettingInfo struct {
+	ZoneID string
+	zones.SettingGetResponse
+}
+
+func listZoneSettings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	zone := h.Item.(zones.Zone)
+	settingId := d.EqualsQualString(matrixKeySetting)
+
+	// Only list settings for zones stated in the input query
+	inputZoneId := d.EqualsQualString("zone_id")
+	if inputZoneId != "" && inputZoneId != zone.ID {
+		return nil, nil
+	}
+
+	// Only list specific setting if requested
+	inputSettingId := d.EqualsQualString("id")
+	if inputSettingId != "" && inputSettingId != settingId {
+		return nil, nil
+	}
+
+	conn, err := connectV4(ctx, d)
+	if err != nil {
+		logger.Error("cloudflare_zone_setting.listZoneSettings", "connection error", err)
+		return nil, err
+	}
+
+	item, err := conn.Zones.Settings.Get(ctx, settingId, zones.SettingGetParams{ZoneID: cloudflare.F(zone.ID)})
+	if err != nil {
+		// Some settings might not be available for all zones
+		if strings.Contains(err.Error(), "Undefined zone setting") {
+			return nil, nil
+		}
+		if strings.Contains(err.Error(), "Access denied") {
+			return nil, nil
+		}
+		logger.Error("cloudflare_zone_setting.listZoneSettings", "ZoneSetting api error", err)
+		return nil, err
+	}
+
+	setting := ZoneSettingInfo{zone.ID, *item}
+
+	d.StreamLeafListItem(ctx, setting)
+	return nil, nil
+}
+
+//// TRANSFORM FUNCTIONS
+
+func transformEditable(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	editable := d.HydrateItem.(ZoneSettingInfo).Editable
+	if editable == zones.SettingGetResponseEditableTrue {
+		return true, nil
+	}
+	return false, nil
+}

--- a/cloudflare/table_cloudflare_zone_setting.go
+++ b/cloudflare/table_cloudflare_zone_setting.go
@@ -3,6 +3,7 @@ package cloudflare
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/cloudflare/cloudflare-go/v4"
 	"github.com/cloudflare/cloudflare-go/v4/zones"
@@ -10,43 +11,6 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 )
-
-const matrixKeySetting = "setting_id"
-
-// BuildZoneSettingMatrix :: return a list of matrix items, one per setting ID.
-// This allows us to query each zone setting individually.
-func BuildZoneSettingMatrix(ctx context.Context, d *plugin.QueryData) []map[string]interface{} {
-	// cache matrix
-	cacheKey := "ZoneSettingMatrix"
-	if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
-		return cachedData.([]map[string]interface{})
-	}
-
-	// Available zone setting IDs
-	settingIds := []string{
-		"0rtt", "advanced_ddos", "always_online", "always_use_https", "automatic_https_rewrites",
-		"brotli", "browser_cache_ttl", "browser_check", "cache_level", "challenge_ttl",
-		"ciphers", "cname_flattening", "development_mode", "early_hints", "edge_cache_ttl",
-		"email_obfuscation", "h2_prioritization", "hotlink_protection", "http2", "http3",
-		"image_resizing", "ip_geolocation", "ipv6", "max_upload", "min_tls_version",
-		"mirage", "nel", "opportunistic_encryption", "opportunistic_onion", "orange_to_orange",
-		"origin_error_page_pass_thru", "origin_h2_max_streams", "origin_max_http_version",
-		"polish", "prefetch_preload", "privacy_pass", "proxy_read_timeout", "pseudo_ipv4",
-		"replace_insecure_js", "response_buffering", "rocket_loader", "automatic_platform_optimization",
-		"security_header", "security_level", "server_side_exclude", "sha1_support",
-		"sort_query_string_for_cache", "ssl", "ssl_recommender", "tls_1_2_only", "tls_1_3",
-		"tls_client_auth", "true_client_ip_header", "waf", "webp", "websockets",
-	}
-
-	matrix := make([]map[string]interface{}, len(settingIds))
-	for i, settingId := range settingIds {
-		matrix[i] = map[string]interface{}{matrixKeySetting: settingId}
-	}
-
-	// set cache
-	d.ConnectionManager.Cache.Set(cacheKey, matrix)
-	return matrix
-}
 
 func tableCloudflareZoneSetting(ctx context.Context) *plugin.Table {
 	return &plugin.Table{
@@ -60,7 +24,6 @@ func tableCloudflareZoneSetting(ctx context.Context) *plugin.Table {
 				{Name: "id", Require: plugin.Optional},
 			},
 		},
-		GetMatrixItemFunc: BuildZoneSettingMatrix,
 		Columns: commonColumns([]*plugin.Column{
 			// Top columns
 			{Name: "id", Type: proto.ColumnType_STRING, Transform: transform.FromField("ID"), Description: "The ID of the zone setting."},
@@ -88,7 +51,6 @@ type ZoneSettingInfo struct {
 func listZoneSettings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	zone := h.Item.(zones.Zone)
-	settingId := d.EqualsQualString(matrixKeySetting)
 
 	// Only list settings for zones stated in the input query
 	inputZoneId := d.EqualsQualString("zone_id")
@@ -96,10 +58,28 @@ func listZoneSettings(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		return nil, nil
 	}
 
-	// Only list specific setting if requested
+	// Check if specific setting is requested
 	inputSettingId := d.EqualsQualString("id")
-	if inputSettingId != "" && inputSettingId != settingId {
-		return nil, nil
+
+	// Available zone setting IDs
+	settingIds := []string{
+		"aegis", "0rtt", "advanced_ddos", "always_online", "always_use_https", "automatic_https_rewrites",
+		"brotli", "browser_cache_ttl", "browser_check", "cache_level", "challenge_ttl",
+		"ciphers", "cname_flattening", "development_mode", "early_hints", "edge_cache_ttl",
+		"email_obfuscation", "h2_prioritization", "hotlink_protection", "http2", "http3",
+		"image_resizing", "ip_geolocation", "ipv6", "max_upload", "min_tls_version",
+		"mirage", "nel", "opportunistic_encryption", "opportunistic_onion", "orange_to_orange",
+		"origin_error_page_pass_thru", "origin_h2_max_streams", "origin_max_http_version",
+		"polish", "prefetch_preload", "privacy_pass", "proxy_read_timeout", "pseudo_ipv4",
+		"replace_insecure_js", "response_buffering", "rocket_loader", "automatic_platform_optimization",
+		"security_header", "security_level", "server_side_exclude", "sha1_support",
+		"sort_query_string_for_cache", "ssl", "ssl_recommender", "tls_1_2_only", "tls_1_3",
+		"tls_client_auth", "true_client_ip_header", "waf", "webp", "websockets",
+	}
+
+	// If specific setting ID is requested, only query that one
+	if inputSettingId != "" {
+		settingIds = []string{inputSettingId}
 	}
 
 	conn, err := connectV4(ctx, d)
@@ -108,22 +88,67 @@ func listZoneSettings(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		return nil, err
 	}
 
-	item, err := conn.Zones.Settings.Get(ctx, settingId, zones.SettingGetParams{ZoneID: cloudflare.F(zone.ID)})
-	if err != nil {
-		// Some settings might not be available for all zones
-		if strings.Contains(err.Error(), "Undefined zone setting") {
-			return nil, nil
+	// Process settings in batches of 10 with parallel API calls
+	// This is to avoid rate limiting by Cloudflare and optimize the query timing
+	batchSize := 10
+	var allSettings []ZoneSettingInfo
+
+	for i := 0; i < len(settingIds); i += batchSize {
+		end := i + batchSize
+		if end > len(settingIds) {
+			end = len(settingIds)
 		}
-		if strings.Contains(err.Error(), "Access denied") {
-			return nil, nil
+
+		batch := settingIds[i:end]
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		var batchSettings []ZoneSettingInfo
+
+		for _, settingId := range batch {
+			wg.Add(1)
+			go func(sid string) {
+				defer wg.Done()
+
+				item, err := conn.Zones.Settings.Get(ctx, sid, zones.SettingGetParams{ZoneID: cloudflare.F(zone.ID)})
+				if err != nil {
+					// Some settings might not be available for all zones
+					if strings.Contains(err.Error(), "Undefined zone setting") {
+						return
+					}
+					if strings.Contains(err.Error(), "Access denied") {
+						return
+					}
+					logger.Error("cloudflare_zone_setting.listZoneSettings", "ZoneSetting api error", err)
+					return
+				}
+
+				setting := ZoneSettingInfo{zone.ID, *item}
+
+				mu.Lock()
+				batchSettings = append(batchSettings, setting)
+				mu.Unlock()
+			}(settingId)
 		}
-		logger.Error("cloudflare_zone_setting.listZoneSettings", "ZoneSetting api error", err)
-		return nil, err
+
+		wg.Wait()
+		allSettings = append(allSettings, batchSettings...)
+
+		// Check if context is cancelled or limit reached
+		if d.RowsRemaining(ctx) == 0 {
+			break
+		}
 	}
 
-	setting := ZoneSettingInfo{zone.ID, *item}
+	// Stream all collected settings
+	for _, setting := range allSettings {
+		d.StreamLeafListItem(ctx, setting)
 
-	d.StreamLeafListItem(ctx, setting)
+		// Check if context is cancelled or limit reached
+		if d.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
+	}
+
 	return nil, nil
 }
 

--- a/docs/tables/cloudflare_zone_setting.md
+++ b/docs/tables/cloudflare_zone_setting.md
@@ -349,8 +349,8 @@ from
   join cloudflare_zone_setting zs2 on zs1.id = zs2.id
   join cloudflare_zone z2 on zs2.zone_id = z2.id
 where
-  z1.name = 'example1.com'
-  and z2.name = 'example2.com'
+  z1.name = 'pleasehelpme.com'
+  and z2.name = 'myactualdomain.com'
   and zs1.id in ('ssl', 'security_level', 'cache_level')
 order by
   zs1.id;

--- a/docs/tables/cloudflare_zone_setting.md
+++ b/docs/tables/cloudflare_zone_setting.md
@@ -12,7 +12,7 @@ Cloudflare Zone Settings control various features and behaviors for a zone, such
 The `cloudflare_zone_setting` table provides insights into individual zone settings within Cloudflare. As a DevOps engineer or security analyst, explore setting-specific details through this table, including current values, editability, and modification timestamps. Utilize it to audit zone configurations, understand security policies, and manage feature settings across your zones.
 
 **Important Notes:**
-- By default this table fetch all settings across all zones.
+- By default this table fetches all settings across all zones.
 - For optimal performance and to reduce query time, always specify `zone_id` and/or `id` (setting ID) in your WHERE clause
 - Possible values for `id` are:
     - `0rtt`

--- a/docs/tables/cloudflare_zone_setting.md
+++ b/docs/tables/cloudflare_zone_setting.md
@@ -13,64 +13,66 @@ The `cloudflare_zone_setting` table provides insights into individual zone setti
 
 **Important Notes:**
 - By default this table fetches all settings across all zones.
-- For optimal performance and to reduce query time, always specify `zone_id` and/or `id` (setting ID) in your WHERE clause
+- For optimal performance and to reduce query time, always specify `zone_id` and/or `id` (setting ID) in your WHERE clause.
+- Use `ids` column to query multiple specific settings efficiently by providing a JSON array of setting IDs.
 - Possible values for `id` are:
-    - `0rtt`
-    - `advanced_ddos`
-    - `always_online`
-    - `always_use_https`
-    - `automatic_https_rewrites`
-    - `brotli`
-    - `browser_cache_ttl`
-    - `browser_check`
-    - `cache_level`
-    - `challenge_ttl`
-    - `ciphers`
-    - `cname_flattening`
-    - `development_mode`
-    - `early_hints`
-    - `edge_cache_ttl`
-    - `email_obfuscation`
-    - `h2_prioritization`
-    - `hotlink_protection`
-    - `http2`
-    - `http3`
-    - `image_resizing`
-    - `ip_geolocation`
-    - `ipv6`
-    - `max_upload`
-    - `min_tls_version`
-    - `mirage`
-    - `nel`
-    - `opportunistic_encryption`
-    - `opportunistic_onion`
-    - `orange_to_orange`
-    - `origin_error_page_pass_thru`
-    - `origin_h2_max_streams`
-    - `origin_max_http_version`
-    - `polish`
-    - `prefetch_preload`
-    - `privacy_pass`
-    - `proxy_read_timeout`
-    - `pseudo_ipv4`
-    - `replace_insecure_js`
-    - `response_buffering`
-    - `rocket_loader`
-    - `automatic_platform_optimization`
-    - `security_header`
-    - `security_level`
-    - `server_side_exclude`
-    - `sha1_support`
-    - `sort_query_string_for_cache`
-    - `ssl`
-    - `ssl_recommender`
-    - `tls_1_2_only`
-    - `tls_1_3`
-    - `tls_client_auth`
-    - `true_client_ip_header`
-    - `waf`
-    - `webp`
-    - `websockets`
+  - `aegis`
+  - `0rtt`
+  - `advanced_ddos`
+  - `always_online`
+  - `always_use_https`
+  - `automatic_https_rewrites`
+  - `brotli`
+  - `browser_cache_ttl`
+  - `browser_check`
+  - `cache_level`
+  - `challenge_ttl`
+  - `ciphers`
+  - `cname_flattening`
+  - `development_mode`
+  - `early_hints`
+  - `edge_cache_ttl`
+  - `email_obfuscation`
+  - `h2_prioritization`
+  - `hotlink_protection`
+  - `http2`
+  - `http3`
+  - `image_resizing`
+  - `ip_geolocation`
+  - `ipv6`
+  - `max_upload`
+  - `min_tls_version`
+  - `mirage`
+  - `nel`
+  - `opportunistic_encryption`
+  - `opportunistic_onion`
+  - `orange_to_orange`
+  - `origin_error_page_pass_thru`
+  - `origin_h2_max_streams`
+  - `origin_max_http_version`
+  - `polish`
+  - `prefetch_preload`
+  - `privacy_pass`
+  - `proxy_read_timeout`
+  - `pseudo_ipv4`
+  - `replace_insecure_js`
+  - `response_buffering`
+  - `rocket_loader`
+  - `automatic_platform_optimization`
+  - `security_header`
+  - `security_level`
+  - `server_side_exclude`
+  - `sha1_support`
+  - `sort_query_string_for_cache`
+  - `ssl`
+  - `ssl_recommender`
+  - `tls_1_2_only`
+  - `tls_1_3`
+  - `tls_client_auth`
+  - `true_client_ip_header`
+  - `waf`
+  - `webp`
+  - `websockets`
 
 ## Examples
 
@@ -239,6 +241,41 @@ where
   zs.id = 'development_mode'
 order by
   z.name;
+```
+
+### Query multiple settings with zone comparison
+Compare multiple settings across zones efficiently using the `ids` column.
+
+```sql+postgres
+select
+  z.name as zone_name,
+  z.type as zone_type,
+  zs.id as setting_id,
+  zs.value,
+  zs.editable
+from
+  cloudflare_zone_setting zs
+  join cloudflare_zone z on zs.zone_id = z.id
+where
+  zs.ids = '["development_mode", "ssl", "security_level"]'
+order by
+  z.name, zs.id;
+```
+
+```sql+sqlite
+select
+  z.name as zone_name,
+  z.type as zone_type,
+  zs.id as setting_id,
+  zs.value,
+  zs.editable
+from
+  cloudflare_zone_setting zs
+  join cloudflare_zone z on zs.zone_id = z.id
+where
+  zs.ids = '["development_mode", "ssl", "security_level"]'
+order by
+  z.name, zs.id;
 ```
 
 ### List editable vs non-editable settings summary

--- a/docs/tables/cloudflare_zone_setting.md
+++ b/docs/tables/cloudflare_zone_setting.md
@@ -1,0 +1,357 @@
+---
+title: "Steampipe Table: cloudflare_zone_setting - Query Cloudflare Zone Settings using SQL"
+description: "Allows users to query individual zone settings in Cloudflare, providing detailed information about each setting's value and configuration."
+---
+
+# Table: cloudflare_zone_setting - Query Cloudflare Zone Settings using SQL
+
+Cloudflare Zone Settings control various features and behaviors for a zone, such as security level, cache settings, SSL configuration, and performance optimizations. Each setting has a specific ID and value that determines how Cloudflare handles requests for that zone.
+
+## Table Usage Guide
+
+The `cloudflare_zone_setting` table provides insights into individual zone settings within Cloudflare. As a DevOps engineer or security analyst, explore setting-specific details through this table, including current values, editability, and modification timestamps. Utilize it to audit zone configurations, understand security policies, and manage feature settings across your zones.
+
+**Important Notes:**
+- By default this table fetch all settings across all zones.
+- For optimal performance and to reduce query time, always specify `zone_id` and/or `id` (setting ID) in your WHERE clause
+- Possible values for `id` are:
+    - `0rtt`
+    - `advanced_ddos`
+    - `always_online`
+    - `always_use_https`
+    - `automatic_https_rewrites`
+    - `brotli`
+    - `browser_cache_ttl`
+    - `browser_check`
+    - `cache_level`
+    - `challenge_ttl`
+    - `ciphers`
+    - `cname_flattening`
+    - `development_mode`
+    - `early_hints`
+    - `edge_cache_ttl`
+    - `email_obfuscation`
+    - `h2_prioritization`
+    - `hotlink_protection`
+    - `http2`
+    - `http3`
+    - `image_resizing`
+    - `ip_geolocation`
+    - `ipv6`
+    - `max_upload`
+    - `min_tls_version`
+    - `mirage`
+    - `nel`
+    - `opportunistic_encryption`
+    - `opportunistic_onion`
+    - `orange_to_orange`
+    - `origin_error_page_pass_thru`
+    - `origin_h2_max_streams`
+    - `origin_max_http_version`
+    - `polish`
+    - `prefetch_preload`
+    - `privacy_pass`
+    - `proxy_read_timeout`
+    - `pseudo_ipv4`
+    - `replace_insecure_js`
+    - `response_buffering`
+    - `rocket_loader`
+    - `automatic_platform_optimization`
+    - `security_header`
+    - `security_level`
+    - `server_side_exclude`
+    - `sha1_support`
+    - `sort_query_string_for_cache`
+    - `ssl`
+    - `ssl_recommender`
+    - `tls_1_2_only`
+    - `tls_1_3`
+    - `tls_client_auth`
+    - `true_client_ip_header`
+    - `waf`
+    - `webp`
+    - `websockets`
+
+## Examples
+
+### List all settings for a specific zone
+Explore all available settings for a particular zone to understand its current configuration. Always specify `zone_id` for better performance.
+
+```sql+postgres
+select
+  id,
+  value,
+  editable,
+  enabled,
+  modified_on
+from
+  cloudflare_zone_setting
+where
+  zone_id = '41b12a8232fe413913ddef4714c0f19b';
+```
+
+```sql+sqlite
+select
+  id,
+  value,
+  editable,
+  enabled,
+  modified_on
+from
+  cloudflare_zone_setting
+where
+  zone_id = '41b12a8232fe413913ddef4714c0f19b';
+```
+
+### Get a specific setting for a specific zone
+Retrieve a single setting for a zone by specifying both `zone_id` and setting `id`. This is the most efficient query pattern.
+
+```sql+postgres
+select
+  id,
+  value,
+  editable,
+  modified_on
+from
+  cloudflare_zone_setting
+where
+  zone_id = '41b12a8232fe413913ddef4714c0f19b'
+  and id = 'ssl';
+```
+
+```sql+sqlite
+select
+  id,
+  value,
+  editable,
+  modified_on
+from
+  cloudflare_zone_setting
+where
+  zone_id = '41b12a8232fe413913ddef4714c0f19b'
+  and id = 'ssl';
+```
+
+### Check SSL/TLS settings across all zones with zone details
+Examine SSL and TLS configuration settings across all your zones, joining with the zone table to get zone names.
+
+```sql+postgres
+select
+  z.name as zone_name,
+  zs.id as setting_id,
+  zs.value,
+  zs.editable,
+  zs.modified_on
+from
+  cloudflare_zone_setting zs
+  join cloudflare_zone z on zs.zone_id = z.id
+where
+  zs.id in ('ssl', 'tls_1_3', 'min_tls_version', 'always_use_https')
+order by
+  z.name, zs.id;
+```
+
+```sql+sqlite
+select
+  z.name as zone_name,
+  zs.id as setting_id,
+  zs.value,
+  zs.editable,
+  zs.modified_on
+from
+  cloudflare_zone_setting zs
+  join cloudflare_zone z on zs.zone_id = z.id
+where
+  zs.id in ('ssl', 'tls_1_3', 'min_tls_version', 'always_use_https')
+order by
+  z.name, zs.id;
+```
+
+### Find zones with specific security settings
+Identify zones that have specific security features enabled or disabled, including zone metadata.
+
+```sql+postgres
+select
+  z.name as zone_name,
+  z.status as zone_status,
+  zs.id as setting_id,
+  zs.value,
+  zs.editable
+from
+  cloudflare_zone_setting zs
+  join cloudflare_zone z on zs.zone_id = z.id
+where
+  zs.id in ('security_level', 'browser_check', 'challenge_ttl')
+  and zs.value != 'off'
+order by
+  z.name;
+```
+
+```sql+sqlite
+select
+  z.name as zone_name,
+  z.status as zone_status,
+  zs.id as setting_id,
+  zs.value,
+  zs.editable
+from
+  cloudflare_zone_setting zs
+  join cloudflare_zone z on zs.zone_id = z.id
+where
+  zs.id in ('security_level', 'browser_check', 'challenge_ttl')
+  and zs.value != 'off'
+order by
+  z.name;
+```
+
+### Query specific setting across all zones with zone info
+Get the value of a particular setting across all your zones, including zone details.
+
+```sql+postgres
+select
+  z.name as zone_name,
+  z.type as zone_type,
+  z.status as zone_status,
+  zs.value,
+  zs.editable,
+  zs.modified_on
+from
+  cloudflare_zone_setting zs
+  join cloudflare_zone z on zs.zone_id = z.id
+where
+  zs.id = 'development_mode'
+order by
+  z.name;
+```
+
+```sql+sqlite
+select
+  z.name as zone_name,
+  z.type as zone_type,
+  z.status as zone_status,
+  zs.value,
+  zs.editable,
+  zs.modified_on
+from
+  cloudflare_zone_setting zs
+  join cloudflare_zone z on zs.zone_id = z.id
+where
+  zs.id = 'development_mode'
+order by
+  z.name;
+```
+
+### List editable vs non-editable settings summary
+Understand which settings can be modified for your zones.
+
+```sql+postgres
+select
+  id as setting_id,
+  editable,
+  count(*) as zone_count,
+  count(case when enabled = true then 1 end) as enabled_count
+from
+  cloudflare_zone_setting
+group by
+  id, editable
+order by
+  id;
+```
+
+```sql+sqlite
+select
+  id as setting_id,
+  editable,
+  count(*) as zone_count,
+  count(case when enabled = 1 then 1 end) as enabled_count
+from
+  cloudflare_zone_setting
+group by
+  id, editable
+order by
+  id;
+```
+
+### Find recently modified settings across zones
+Identify settings that have been recently modified, useful for auditing configuration changes.
+
+```sql+postgres
+select
+  z.name as zone_name,
+  zs.id as setting_id,
+  zs.value,
+  zs.modified_on
+from
+  cloudflare_zone_setting zs
+  join cloudflare_zone z on zs.zone_id = z.id
+where
+  zs.modified_on >= now() - interval '7 days'
+order by
+  zs.modified_on desc;
+```
+
+```sql+sqlite
+select
+  z.name as zone_name,
+  zs.id as setting_id,
+  zs.value,
+  zs.modified_on
+from
+  cloudflare_zone_setting zs
+  join cloudflare_zone z on zs.zone_id = z.id
+where
+  zs.modified_on >= datetime('now', '-7 days')
+order by
+  zs.modified_on desc;
+```
+
+### Compare settings between zones
+Compare specific settings between different zones to ensure consistency.
+
+```sql+postgres
+select
+  zs1.id as setting_id,
+  z1.name as zone1_name,
+  zs1.value as zone1_value,
+  z2.name as zone2_name,
+  zs2.value as zone2_value,
+  case
+    when zs1.value = zs2.value then 'Match'
+    else 'Different'
+  end as comparison
+from
+  cloudflare_zone_setting zs1
+  join cloudflare_zone z1 on zs1.zone_id = z1.id
+  join cloudflare_zone_setting zs2 on zs1.id = zs2.id
+  join cloudflare_zone z2 on zs2.zone_id = z2.id
+where
+  z1.name = 'pleasehelpme.com'
+  and z2.name = 'myactualdomain.com'
+  and zs1.id in ('ssl', 'security_level', 'cache_level')
+order by
+  zs1.id;
+```
+
+```sql+sqlite
+select
+  zs1.id as setting_id,
+  z1.name as zone1_name,
+  zs1.value as zone1_value,
+  z2.name as zone2_name,
+  zs2.value as zone2_value,
+  case
+    when zs1.value = zs2.value then 'Match'
+    else 'Different'
+  end as comparison
+from
+  cloudflare_zone_setting zs1
+  join cloudflare_zone z1 on zs1.zone_id = z1.id
+  join cloudflare_zone_setting zs2 on zs1.id = zs2.id
+  join cloudflare_zone z2 on zs2.zone_id = z2.id
+where
+  z1.name = 'example1.com'
+  and z2.name = 'example2.com'
+  and zs1.id in ('ssl', 'security_level', 'cache_level')
+order by
+  zs1.id;
+```


### PR DESCRIPTION

# Example query results

<details>
  <summary>Results</summary>

```
> select
  zs1.id as setting_id,
  z1.name as zone1_name,
  zs1.value as zone1_value,
  z2.name as zone2_name,
  zs2.value as zone2_value,
  case
    when zs1.value = zs2.value then 'Match'
    else 'Different'
  end as comparison
from
  cloudflare_zone_setting zs1
  join cloudflare_zone z1 on zs1.zone_id = z1.id
  join cloudflare_zone_setting zs2 on zs1.id = zs2.id
  join cloudflare_zone z2 on zs2.zone_id = z2.id
where
  z1.name = 'pleasehelpme.com'
  and z2.name = 'myactualdomain.com'
  and zs1.id in ('ssl', 'security_level', 'cache_level')
order by
  zs1.id;
+----------------+------------------+-------------+--------------------+-------------+------------+
| setting_id     | zone1_name       | zone1_value | zone2_name         | zone2_value | comparison |
+----------------+------------------+-------------+--------------------+-------------+------------+
| cache_level    | pleasehelpme.com | aggressive  | myactualdomain.com | aggressive  | Match      |
| security_level | pleasehelpme.com | medium      | myactualdomain.com | medium      | Match      |
| ssl            | pleasehelpme.com | full        | myactualdomain.com | full        | Match      |
+----------------+------------------+-------------+--------------------+-------------+------------+
```

</details>
