### PR TITLE
fix: null TTL value on cloudflare_dns_record table

### DIFF
--- a/cloudflare/table_cloudflare_dns_record.go
+++ b/cloudflare/table_cloudflare_dns_record.go
@@ -36,7 +36,7 @@ func tableCloudflareDNSRecord(ctx context.Context) *plugin.Table {
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "Domain name for the record (e.g. steampipe.io)."},
 			{Name: "content", Type: proto.ColumnType_STRING, Description: "Content or value of the record. Changes by type, including IP address for A records and domain for CNAME records."},
 			
-			// Property ttl is NULL without the transfrom FromField function
+			// Property ttl is NULL without the transform FromField function
 			{Name: "ttl", Type: proto.ColumnType_DOUBLE,Transform: transform.FromField("TTL"), Description: "Time to live in seconds of the record."},
 
 			// Other columns

--- a/cloudflare/table_cloudflare_dns_record.go
+++ b/cloudflare/table_cloudflare_dns_record.go
@@ -35,7 +35,9 @@ func tableCloudflareDNSRecord(ctx context.Context) *plugin.Table {
 			{Name: "type", Type: proto.ColumnType_STRING, Description: "Type of the record (e.g. A, MX, CNAME)."},
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "Domain name for the record (e.g. steampipe.io)."},
 			{Name: "content", Type: proto.ColumnType_STRING, Description: "Content or value of the record. Changes by type, including IP address for A records and domain for CNAME records."},
-			{Name: "ttl", Type: proto.ColumnType_INT, Description: "Time to live in seconds of the record."},
+			
+			// Property ttl is NULL without the transfrom FromField function
+			{Name: "ttl", Type: proto.ColumnType_DOUBLE,Transform: transform.FromField("TTL"), Description: "Time to live in seconds of the record."},
 
 			// Other columns
 			{Name: "created_on", Type: proto.ColumnType_TIMESTAMP, Description: "When the record was created."},


### PR DESCRIPTION
# Example query results

<details>
  <summary>Results</summary>

```
SELECT 
  id, 
  name, 
  ttl 
FROM 
  cloudflare_dns_record 
WHERE
 zone_id = 'abc5n4dfgh2k1jxyz57Efef5d4c3b2a1'
+----------------------------------+-------------------------+-----+
| id                               | name                    | ttl |
+----------------------------------+-------------------------+-----+
| a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6 | example1.com            | 1   |
| p6o5n4m3l2k1j0i9h8g7f6e5d4c3b2a1 | www.example1.com        | 1   |
| z9y8x7w6v5u4t3s2r1q0p9o8n7m6k5j4 | preprod.example1.com    | 1   |
| k5j4m6n7o8p9q0r1s2t3u4v5w6x7y8z9 | recette.example1.com    | 1   |
| x1y2z3w4v5u6t7s8r9q0p1o2n3m4k5j6 | prod.example1.com       | 1   |
+----------------------------------+-------------------------+-----+
```

</details>
