### PR TITLE
fix/cloudflare load balancer pool - add health column

### DIFF
--- a/cloudflare/table_cloudflare_load_balancer_pool.go
+++ b/cloudflare/table_cloudflare_load_balancer_pool.go
@@ -84,6 +84,7 @@ func getLoadBalancerPoolHealth(ctx context.Context, d *plugin.QueryData, h *plug
 	logger := plugin.Logger(ctx)
 	conn, err := connectV4(ctx, d)
 	if err != nil {
+		logger.Error("cloudflare_load_balancer_pool.getLoadBalancerPoolHealth", "connection_error", err)
 		return nil, err
 	}
 	pool := h.Item.(load_balancers.Pool)
@@ -100,7 +101,7 @@ func getLoadBalancerPoolHealth(ctx context.Context, d *plugin.QueryData, h *plug
 			return nil, nil
 		}
 		logger.Error("cloudflare_load_balancer_pool.getLoadBalancerPoolHealth", "load balancer pool health API error", err)
-		return nil, nil
+		return nil, err
 	}
 	return pool_health, nil
 }


### PR DESCRIPTION
# Example query results

<details>
  <summary>Results</summary>

```
select id, name, health from cloudflare_load_balancer_pool
+----------------------------------+-------------+----------------------------------------------------------------------------------------------+
| id                               | name        | health                                                                                       |
+----------------------------------+-------------+----------------------------------------------------------------------------------------------+
| 54db6441547a173e35f827abc503dfg8 | lb-pool1    | {"pool_id":"54db6441547a173e35f827abc503dfg8","pop_health":{"healthy":false,"origins":null}} |
| 97f76012be00d4b974f36d3eaf820y6t | lb-pool2    | <null>                                                                                       |
+----------------------------------+-------------+----------------------------------------------------------------------------------------------+
```

lb-pool1 : No monitoring configured
lb-pool2 : Monitoring configured
</details>
