### PR TITLE
feat: add cloudflare_custom_page table

### DIFF
--- a/cloudflare/plugin.go
+++ b/cloudflare/plugin.go
@@ -43,6 +43,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"cloudflare_worker_route":          tableCloudflareWorkerRoute(ctx),
 			"cloudflare_zone":                  tableCloudflareZone(ctx),
 			"cloudflare_zone_setting":          tableCloudflareZoneSetting(ctx),
+			"cloudflare_custom_page":          	tableCloudflareCustomPage(ctx),
 		},
 	}
 	return p

--- a/cloudflare/plugin.go
+++ b/cloudflare/plugin.go
@@ -28,6 +28,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"cloudflare_account_member":        tableCloudflareAccountMember(ctx),
 			"cloudflare_account_role":          tableCloudflareAccountRole(ctx),
 			"cloudflare_api_token":             tableCloudflareAPIToken(ctx),
+			"cloudflare_custom_page":           tableCloudflareCustomPage(ctx),
 			"cloudflare_dns_record":            tableCloudflareDNSRecord(ctx),
 			"cloudflare_firewall_rule":         tableCloudflareFirewallRule(ctx),
 			"cloudflare_load_balancer":         tableCloudflareLoadBalancer(ctx),
@@ -43,7 +44,6 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"cloudflare_worker_route":          tableCloudflareWorkerRoute(ctx),
 			"cloudflare_zone":                  tableCloudflareZone(ctx),
 			"cloudflare_zone_setting":          tableCloudflareZoneSetting(ctx),
-			"cloudflare_custom_page":           tableCloudflareCustomPage(ctx),		
 		},
 	}
 	return p

--- a/cloudflare/plugin.go
+++ b/cloudflare/plugin.go
@@ -43,7 +43,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"cloudflare_worker_route":          tableCloudflareWorkerRoute(ctx),
 			"cloudflare_zone":                  tableCloudflareZone(ctx),
 			"cloudflare_zone_setting":          tableCloudflareZoneSetting(ctx),
-			"cloudflare_custom_page":          	tableCloudflareCustomPage(ctx),
+			"cloudflare_custom_page":           tableCloudflareCustomPage(ctx),		
 		},
 	}
 	return p

--- a/cloudflare/table_cloudflare_custom_page.go
+++ b/cloudflare/table_cloudflare_custom_page.go
@@ -2,7 +2,6 @@ package cloudflare
 
 import (
 	"context"
-	"time"
 
 	"github.com/cloudflare/cloudflare-go/v4"
 	"github.com/cloudflare/cloudflare-go/v4/custom_pages"
@@ -10,19 +9,6 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 )
-
-// CUSTOM PAGE STRUCT DEFINITION
-
-type CustomPage struct {
-	ID            string    `json:"id"`
-	Description   string    `json:"description"`
-	State         string    `json:"state"`
-	URL           string    `json:"url"`
-	ModifiedOn    time.Time `json:"modified_on"`
-	CreatedOn     time.Time `json:"created_on"`
-	RequiredTokens []string `json:"required_tokens"`
-	PreviewTarget string    `json:"preview_target"`
-}
 
 //// TABLE DEFINITION
 
@@ -52,7 +38,7 @@ func tableCloudflareCustomPage(ctx context.Context) *plugin.Table {
 			{Name: "description", Type: proto.ColumnType_STRING, Transform: transform.FromField("description"), Description: "Custom page description."},
 			{Name: "state", Type: proto.ColumnType_STRING, Transform: transform.FromField("state"), Description: "The custom page state."},
 			{Name: "url", Type: proto.ColumnType_STRING, Transform: transform.FromField("url"), Description: "The URL associated with the custom page."},
-			{Name: "modified_on", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("modified_on"), Description: "When the setting was last modified."},
+			{Name: "modified_on", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("modified_on"), Description: "When the custom page was last modified."},
 			{Name: "created_on", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("created_on"), Description: "When the custom page was created."},
 			{Name: "preview_target", Type: proto.ColumnType_STRING, Transform: transform.FromField("preview_target"), Description: "Preview action to apply."},
 

--- a/cloudflare/table_cloudflare_custom_page.go
+++ b/cloudflare/table_cloudflare_custom_page.go
@@ -1,0 +1,260 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cloudflare/cloudflare-go/v4"
+	"github.com/cloudflare/cloudflare-go/v4/custom_pages"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+// CUSTOM PAGE STRUCT DEFINITION
+
+type CustomPage struct {
+	ID            string    `json:"id"`
+	Description   string    `json:"description"`
+	State         string    `json:"state"`
+	URL           string    `json:"url"`
+	ModifiedOn    time.Time `json:"modified_on"`
+	CreatedOn     time.Time `json:"created_on"`
+	RequiredTokens []string `json:"required_tokens"`
+	PreviewTarget string    `json:"preview_target"`
+}
+
+//// TABLE DEFINITION
+
+func tableCloudflareCustomPage(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "cloudflare_custom_page",
+		Description: "",
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "account_id", Require: plugin.AnyOf},
+				{Name: "zone_id", Require: plugin.AnyOf},
+			},
+			Hydrate: listCustomPages,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "id", Require: plugin.Required},
+				{Name: "account_id", Require: plugin.AnyOf},
+				{Name: "zone_id", Require: plugin.AnyOf},
+			},
+			ShouldIgnoreError: isNotFoundError([]string{"Invalid custom page identifier"}),
+			Hydrate:           getCustomPage,
+		},
+		Columns: commonColumns([]*plugin.Column{
+			// Top columns
+			{Name: "id", Type: proto.ColumnType_STRING,Transform: transform.FromField("ID"),Description: "Custom page identifier."},
+			{Name: "description", Type: proto.ColumnType_STRING, Description: "Custom page descriptionn."},
+			{Name: "state", Type: proto.ColumnType_STRING, Description: "The custom page state."},
+			{Name: "url", Type: proto.ColumnType_STRING, Description: "The URL associated with the custom page."},
+			{Name: "modified_on", Type: proto.ColumnType_TIMESTAMP, Description: "When the setting was last modified."},
+			{Name: "created_on", Type: proto.ColumnType_TIMESTAMP, Description: "When the custom page was created."},
+			{Name: "preview_target", Type: proto.ColumnType_STRING, Description: "Preview action to apply."},
+
+			// Query columns for filtering
+			{Name: "account_id", Type: proto.ColumnType_STRING, Transform: transform.FromQual("account_id"), Description: "The account ID to filter rulesets."},
+			{Name: "zone_id", Type: proto.ColumnType_STRING, Transform: transform.FromQual("zone_id"), Description: "The zone ID to filter rulesets."},
+
+			// JSON Columns
+			{Name: "required_tokens", Type: proto.ColumnType_JSON, Description: "Error tokens are required by the custom page."},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+// listCustomPages retrieves all custom pages for the specified account_id or zone_id.
+//
+// This function handles both account-level and zone-level custom pages:
+// - Account-level rulesets (account_id)
+// - Zone-level rulesets (zone_id)
+func listCustomPages(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	conn, err := connectV4(ctx, d)
+	if err != nil {
+		logger.Error("cloudflare_custom_pages.listCustomPages", "connection_error", err)
+		return nil, err
+	}
+
+	// Get the qualifiers
+	quals := d.EqualsQuals
+	accountID := ""
+	zoneID := ""
+
+	if quals["account_id"] != nil {
+		accountID = quals["account_id"].GetStringValue()
+	}
+	if quals["zone_id"] != nil {
+		zoneID = quals["zone_id"].GetStringValue()
+	}
+
+	// Build API parameters based on account or zone context
+	input := custom_pages.CustomPageListParams{}
+	if accountID != "" {
+		input.AccountID = cloudflare.F(accountID)
+	}
+	if zoneID != "" {
+		input.ZoneID = cloudflare.F(zoneID)
+	}
+
+	// Execute paginated API call
+	iter := conn.CustomPages.ListAutoPaging(ctx, input)
+	for iter.Next() {
+		current := iter.Current()
+
+		// Needs manual mapping because CustomPageListResponse type is interface{}
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			logger.Warn("Unexpected type", fmt.Sprintf("%T", current))
+			continue
+		}
+		logger.Debug("Réponse API", "data", m)
+		cp := CustomPage{
+			ID:            toString(m["id"]),
+			Description:   toString(m["description"]),
+			State:         toString(m["state"]),
+			URL:           toString(m["url"]),
+			PreviewTarget: toString(m["preview_target"]),
+		}
+
+		if createdOn, ok := m["created_on"]; ok {
+			if t, err := toTime(createdOn); err == nil {
+				cp.CreatedOn = t
+			} else {
+				logger.Warn("Invalid created_on format", "error", err)
+			}
+		}
+
+		if modifiedOn, ok := m["modified_on"]; ok {
+			if t, err := toTime(modifiedOn); err == nil {
+				cp.ModifiedOn = t
+			} else {
+				logger.Warn("Invalid modified_on format", "error", err)
+			}
+		}
+
+		if tokens, ok := m["required_tokens"]; ok {
+			if arr, ok := tokens.([]interface{}); ok {
+				for _, token := range arr {
+					if str, ok := token.(string); ok {
+						cp.RequiredTokens = append(cp.RequiredTokens, str)
+					}
+				}
+			}
+		}
+
+		d.StreamListItem(ctx, cp)
+
+		if d.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
+	}
+	if err := iter.Err(); err != nil {
+		logger.Error("cloudflare_custom_pages.listCustomPages", "ListAutoPaging error", err)
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// GET FUNCTION
+
+// getCustomPage retrieves a specific custom page by ID.
+// Parameters:
+// - id: The custom page identifier (required)
+// - account_id OR zone_id: The account or zone context (at least one required)
+
+func getCustomPage(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	conn, err := connectV4(ctx, d)
+	if err != nil {
+		logger.Error("cloudflare_custom_pages.getRuleset", "connection_error", err)
+		return nil, err
+	}
+	quals := d.EqualsQuals
+	customPageID := quals["id"].GetStringValue()
+	accountID := quals["account_id"].GetStringValue()
+	zoneID := quals["zone_id"].GetStringValue()
+
+	// Build API parameters with appropriate context
+	input := custom_pages.CustomPageGetParams{}
+	if accountID != "" {
+		input.AccountID = cloudflare.F(accountID)
+	}
+	if zoneID != "" {
+		input.ZoneID = cloudflare.F(zoneID)
+	}
+
+	// Execute API call to get the specific custom page
+	customPage, err := conn.CustomPages.Get(ctx, customPageID, input)
+	raw := *customPage
+	m, ok := raw.(map[string]interface{})
+		if !ok {
+			logger.Warn("Unexpected type", fmt.Sprintf("%T", customPage))
+			return nil, nil
+		}
+
+	// Needs manual mapping because CustomPages.Get return type is *interface{}
+	cp := CustomPage{
+			ID:            toString(m["id"]),
+			Description:   toString(m["description"]),
+			State:         toString(m["state"]),
+			URL:           toString(m["url"]),
+			PreviewTarget: toString(m["preview_target"]),
+		}
+
+		if createdOn, ok := m["created_on"]; ok {
+			if t, err := toTime(createdOn); err == nil {
+				cp.CreatedOn = t
+			} else {
+				logger.Warn("Invalid created_on format", "error", err)
+			}
+		}
+
+		if modifiedOn, ok := m["modified_on"]; ok {
+			if t, err := toTime(modifiedOn); err == nil {
+				cp.ModifiedOn = t
+			} else {
+				logger.Warn("Invalid modified_on format", "error", err)
+			}
+		}
+
+		if tokens, ok := m["required_tokens"]; ok {
+			if arr, ok := tokens.([]interface{}); ok {
+				for _, token := range arr {
+					if str, ok := token.(string); ok {
+						cp.RequiredTokens = append(cp.RequiredTokens, str)
+					}
+				}
+			}
+		}
+
+	if err != nil {
+		logger.Error("cloudflare_custom_pages.getCustomPages", "error", err)
+		return nil, err
+	}
+
+	return cp, nil
+}
+
+// OTHER FUNCTIONS
+
+func toString(v interface{}) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func toTime(v interface{}) (time.Time, error) {
+	if s, ok := v.(string); ok {
+		return time.Parse(time.RFC3339, s)
+	}
+	return time.Time{}, fmt.Errorf("invalid time format: %v", v)
+}

--- a/cloudflare/table_cloudflare_custom_page.go
+++ b/cloudflare/table_cloudflare_custom_page.go
@@ -50,7 +50,7 @@ func tableCloudflareCustomPage(ctx context.Context) *plugin.Table {
 		Columns: commonColumns([]*plugin.Column{
 			// Top columns
 			{Name: "id", Type: proto.ColumnType_STRING,Transform: transform.FromField("ID"),Description: "Custom page identifier."},
-			{Name: "description", Type: proto.ColumnType_STRING, Description: "Custom page descriptionn."},
+			{Name: "description", Type: proto.ColumnType_STRING, Description: "Custom page description."},
 			{Name: "state", Type: proto.ColumnType_STRING, Description: "The custom page state."},
 			{Name: "url", Type: proto.ColumnType_STRING, Description: "The URL associated with the custom page."},
 			{Name: "modified_on", Type: proto.ColumnType_TIMESTAMP, Description: "When the setting was last modified."},
@@ -72,8 +72,8 @@ func tableCloudflareCustomPage(ctx context.Context) *plugin.Table {
 // listCustomPages retrieves all custom pages for the specified account_id or zone_id.
 //
 // This function handles both account-level and zone-level custom pages:
-// - Account-level rulesets (account_id)
-// - Zone-level rulesets (zone_id)
+// - Account-level custom pages (account_id)
+// - Zone-level custom pages (zone_id)
 func listCustomPages(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	conn, err := connectV4(ctx, d)
@@ -114,7 +114,7 @@ func listCustomPages(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 			logger.Warn("Unexpected type", fmt.Sprintf("%T", current))
 			continue
 		}
-		logger.Debug("Réponse API", "data", m)
+
 		cp := CustomPage{
 			ID:            toString(m["id"]),
 			Description:   toString(m["description"]),
@@ -174,7 +174,7 @@ func getCustomPage(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	logger := plugin.Logger(ctx)
 	conn, err := connectV4(ctx, d)
 	if err != nil {
-		logger.Error("cloudflare_custom_pages.getRuleset", "connection_error", err)
+		logger.Error("cloudflare_custom_pages.getCustomPage", "connection_error", err)
 		return nil, err
 	}
 	quals := d.EqualsQuals
@@ -193,6 +193,11 @@ func getCustomPage(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 
 	// Execute API call to get the specific custom page
 	customPage, err := conn.CustomPages.Get(ctx, customPageID, input)
+	if err != nil {
+		logger.Error("cloudflare_custom_pages.getCustomPages", "error", err)
+		return nil, err
+	}
+
 	raw := *customPage
 	m, ok := raw.(map[string]interface{})
 		if !ok {
@@ -234,11 +239,6 @@ func getCustomPage(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 				}
 			}
 		}
-
-	if err != nil {
-		logger.Error("cloudflare_custom_pages.getCustomPages", "error", err)
-		return nil, err
-	}
 
 	return cp, nil
 }

--- a/cloudflare/table_cloudflare_custom_page.go
+++ b/cloudflare/table_cloudflare_custom_page.go
@@ -58,8 +58,8 @@ func tableCloudflareCustomPage(ctx context.Context) *plugin.Table {
 			{Name: "preview_target", Type: proto.ColumnType_STRING, Description: "Preview action to apply."},
 
 			// Query columns for filtering
-			{Name: "account_id", Type: proto.ColumnType_STRING, Transform: transform.FromQual("account_id"), Description: "The account ID to filter rulesets."},
-			{Name: "zone_id", Type: proto.ColumnType_STRING, Transform: transform.FromQual("zone_id"), Description: "The zone ID to filter rulesets."},
+			{Name: "account_id", Type: proto.ColumnType_STRING, Transform: transform.FromQual("account_id"), Description: "The account ID to filter custom pages."},
+			{Name: "zone_id", Type: proto.ColumnType_STRING, Transform: transform.FromQual("zone_id"), Description: "The zone ID to filter custom pages."},
 
 			// JSON Columns
 			{Name: "required_tokens", Type: proto.ColumnType_JSON, Description: "Error tokens are required by the custom page."},

--- a/cloudflare/table_cloudflare_custom_page.go
+++ b/cloudflare/table_cloudflare_custom_page.go
@@ -2,7 +2,6 @@ package cloudflare
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/cloudflare/cloudflare-go/v4"

--- a/cloudflare/table_cloudflare_custom_page.go
+++ b/cloudflare/table_cloudflare_custom_page.go
@@ -159,19 +159,3 @@ func getCustomPage(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 
 	return *customPage, nil
 }
-
-// OTHER FUNCTIONS
-
-func toString(v interface{}) string {
-	if s, ok := v.(string); ok {
-		return s
-	}
-	return ""
-}
-
-func toTime(v interface{}) (time.Time, error) {
-	if s, ok := v.(string); ok {
-		return time.Parse(time.RFC3339, s)
-	}
-	return time.Time{}, fmt.Errorf("invalid time format: %v", v)
-}

--- a/docs/tables/cloudflare_custom_page.md
+++ b/docs/tables/cloudflare_custom_page.md
@@ -86,7 +86,7 @@ from
   cloudflare_custom_page
 where
   id = 'CUSTOM_PAGE_ID'
-  account_id = 'YOUR_ACCOUNT_ID';
+  and account_id = 'YOUR_ACCOUNT_ID';
 ```
 
 ```sql+sqlite
@@ -101,7 +101,7 @@ from
   cloudflare_custom_page
 where
   id = 'CUSTOM_PAGE_ID'
-  account_id = 'YOUR_ACCOUNT_ID';
+  and account_id = 'YOUR_ACCOUNT_ID';
 ```
 
 ### Query all custom pages recently created
@@ -146,7 +146,7 @@ from
   cloudflare_custom_page
 where
   account_id = 'YOUR_ACCOUNT_ID'
-  and state == 'customized';
+  and state = 'customized';
 ```
 
 ```sql+sqlite
@@ -159,5 +159,5 @@ from
   cloudflare_custom_page
 where
   account_id = 'YOUR_ACCOUNT_ID'
-  and state == 'customized';
+  and state = 'customized';
 ```

--- a/docs/tables/cloudflare_custom_page.md
+++ b/docs/tables/cloudflare_custom_page.md
@@ -16,7 +16,7 @@ The `cloudflare_custom_page` table provides insight into configurable custom pag
 
 ## Examples
 
-### Query all custom pages for a zone/account
+### Query all custom pages for a zone
 Retrieves all custom pages that are associated with a specific zone ID in the cloudflare_custom_page table.
 
 ```sql+postgres
@@ -47,6 +47,7 @@ where
   zone_id = 'YOUR_ZONE_ID';
 ```
 
+### Query all custom pages for an account
 Retrieves all custom pages that are associated with a specific account ID in the cloudflare_custom_page table.
 
 ```sql+postgres
@@ -140,7 +141,7 @@ where
   account_id = 'YOUR_ACCOUNT_ID'
   and datetime(created_on) >= datetime('now', '-7 days')
 order by
-  created_on DESC;
+  created_on desc;
 ```
 
 ### Query all customized error pages

--- a/docs/tables/cloudflare_custom_page.md
+++ b/docs/tables/cloudflare_custom_page.md
@@ -1,0 +1,163 @@
+---
+title: "Steampipe Table: cloudflare_custom_page - Query Cloudflare Custom Pages using SQL"
+description: "Allows users to query Cloudflare Custom Pages, providing access to custom error or status page configurations, including page IDs, descriptions, states, URLs, creation and modification timestamps, preview targets, and required tokens at account or zone levels."
+---
+
+# Table: cloudflare_custom_page - Query Cloudflare Custom Pages using SQL
+
+Custom Pages allow Cloudflare users to define custom error and status pages for display to end users. These pages support templated tokens and preview targets, and can be scoped at either the account or zone level.
+
+## Table Usage Guide
+
+The `cloudflare_custom_page` table provides insight into configurable custom page definitions within Cloudflare. As a security administrator or DevOps engineer, you can explore page-specific details, including page ID, description, state, URL, required tokens, preview target, creation timestamp and last modification timestamp. Use it to audit page customizations, monitor outdated error pages, and verify token usage for dynamic content rendering across account or zone contexts.
+
+**Important Notes**
+- You must specify either `account_id` or `zone_id` in a `where` or `join` clause to query this table.
+
+## Examples
+
+### Query all custom pages for a zone/account
+```sql+postgres
+select
+  id,
+  description,
+  state,
+  url,
+  created_on,
+  modified_on
+from
+  cloudflare_custom_page
+where
+  zone_id    = 'YOUR_ZONE_ID';
+```
+
+```sql+sqlite
+select
+  id,
+  description,
+  state,
+  url,
+  created_on,
+  modified_on
+from
+  cloudflare_custom_page
+where
+  zone_id    = 'YOUR_ZONE_ID';
+```
+
+```sql+postgres
+select
+  id,
+  description,
+  state,
+  url,
+  created_on,
+  modified_on
+from
+  cloudflare_custom_page
+where
+  account_id    = 'YOUR_ACCOUNT_ID';
+```
+
+```sql+sqlite
+select
+  id,
+  description,
+  state,
+  url,
+  created_on,
+  modified_on
+from
+  cloudflare_custom_page
+where
+  account_id    = 'YOUR_ACCOUNT_ID';
+```
+
+### Get a specific custom page by ID
+```sql+postgres
+select
+  id,
+  description,
+  state,
+  url,
+  preview_target,
+  required_tokens
+from
+  cloudflare_custom_page
+where
+  id = 'CUSTOM_PAGE_ID'
+  account_id = 'YOUR_ACCOUNT_ID';
+```
+
+```sql+sqlite
+select
+  id,
+  description,
+  state,
+  url,
+  preview_target,
+  required_tokens
+from
+  cloudflare_custom_page
+where
+  id = 'CUSTOM_PAGE_ID'
+  account_id = 'YOUR_ACCOUNT_ID';
+```
+
+### Query all custom pages recently created
+```sql+postgres
+select
+  id,
+  description,
+  state,
+  created_on
+from
+  cloudflare_custom_page
+where
+  account_id = 'YOUR_ACCOUNT_ID'
+  and created_on >= now() - interval '7 days'
+order by
+  created_on desc;
+```
+
+```sql+sqlite
+SELECT
+  id,
+  description,
+  state,
+  created_on
+FROM
+  cloudflare_custom_page
+WHERE
+  account_id = 'YOUR_ACCOUNT_ID'
+  AND datetime(created_on) >= datetime('now', '-7 days')
+ORDER BY
+  created_on DESC;
+```
+
+### Query all customized error pages
+```sql+postgres
+select
+  id,
+  description,
+  state,
+  url
+from
+  cloudflare_custom_page
+where
+  account_id = 'YOUR_ACCOUNT_ID'
+  and state == 'customized';
+```
+
+```sql+sqlite
+select
+  id,
+  description,
+  state,
+  url
+from
+  cloudflare_custom_page
+where
+  account_id = 'YOUR_ACCOUNT_ID'
+  and state == 'customized';
+```

--- a/docs/tables/cloudflare_custom_page.md
+++ b/docs/tables/cloudflare_custom_page.md
@@ -17,6 +17,8 @@ The `cloudflare_custom_page` table provides insight into configurable custom pag
 ## Examples
 
 ### Query all custom pages for a zone/account
+Retrieves all custom pages that are associated with a specific zone ID in the cloudflare_custom_page table.
+
 ```sql+postgres
 select
   id,
@@ -28,7 +30,7 @@ select
 from
   cloudflare_custom_page
 where
-  zone_id    = 'YOUR_ZONE_ID';
+  zone_id = 'YOUR_ZONE_ID';
 ```
 
 ```sql+sqlite
@@ -42,8 +44,10 @@ select
 from
   cloudflare_custom_page
 where
-  zone_id    = 'YOUR_ZONE_ID';
+  zone_id = 'YOUR_ZONE_ID';
 ```
+
+Retrieves all custom pages that are associated with a specific account ID in the cloudflare_custom_page table.
 
 ```sql+postgres
 select
@@ -56,7 +60,7 @@ select
 from
   cloudflare_custom_page
 where
-  account_id    = 'YOUR_ACCOUNT_ID';
+  account_id = 'YOUR_ACCOUNT_ID';
 ```
 
 ```sql+sqlite
@@ -70,10 +74,12 @@ select
 from
   cloudflare_custom_page
 where
-  account_id    = 'YOUR_ACCOUNT_ID';
+  account_id = 'YOUR_ACCOUNT_ID';
 ```
 
 ### Get a specific custom page by ID
+Retrieves detailed information about a specific custom page.
+
 ```sql+postgres
 select
   id,
@@ -105,6 +111,8 @@ where
 ```
 
 ### Query all custom pages recently created
+Retrieves all custom pages created within the last 7 days for a specific account_id.
+
 ```sql+postgres
 select
   id,
@@ -121,21 +129,23 @@ order by
 ```
 
 ```sql+sqlite
-SELECT
+select
   id,
   description,
   state,
   created_on
-FROM
+from
   cloudflare_custom_page
-WHERE
+where
   account_id = 'YOUR_ACCOUNT_ID'
-  AND datetime(created_on) >= datetime('now', '-7 days')
-ORDER BY
+  and datetime(created_on) >= datetime('now', '-7 days')
+order by
   created_on DESC;
 ```
 
 ### Query all customized error pages
+Fetches all error pages that have been customized for a specific account ID. The results are filtered to only include pages where state is set to 'customized'.
+
 ```sql+postgres
 select
   id,


### PR DESCRIPTION
# Example query results

<details>
  <summary>Results</summary>

```
SELECT 
  z.id as zone_id, 
  z.name as zone_name, 
  c.id, 
  c.description, 
  c.state, 
  c.url, 
  c.modified_on, 
  c.created_on, 
  c.preview_target, 
  c.required_tokens 
FROM 
  cloudflare_custom_page as c 
JOIN 
  cloudflare_zone as z 
ON 
 z.id = c.zone_id
+----------------------------------+------------------------------+-------------------+------------------------------+---------+--------+---------------------------+---------------------------+-------------------------+------------------------------------+
| zone_id                          | zone_name                    | id                | description                  | state   | url    | modified_on               | created_on                | preview_target          | required_tokens                    |
+----------------------------------+------------------------------+-------------------+------------------------------+---------+--------+---------------------------+---------------------------+-------------------------+------------------------------------+
| 88e09f3f4e8e0ecd429df624f9746a1c | test.com                     | 1000_errors       | 10XX Errors                  | default | <null> | 0001-01-01T00:09:21+00:09 | 0001-01-01T00:09:21+00:09 | cf-error:1000s          | ["::CLOUDFLARE_ERROR_1000S_BOX::"] |
| 88e09f3f4e8e0ecd429df624f9746a1c | test.com                     | country_challenge | Country Challenge            | default | <null> | 0001-01-01T00:09:21+00:09 | 0001-01-01T00:09:21+00:09 | block:country-captcha   | ["::CAPTCHA_BOX::"]                |
| 88e09f3f4e8e0ecd429df624f9746a1c | test.com                     | under_attack      | I'm Under Attack Mode        | default | <null> | 0001-01-01T00:09:21+00:09 | 0001-01-01T00:09:21+00:09 | block:iuam-basic        | ["::IM_UNDER_ATTACK_BOX::"]        |
| 88e09f3f4e8e0ecd429df624f9746a1c | test.com                     | basic_challenge   | Basic Challenge              | default | <null> | 0001-01-01T00:09:21+00:09 | 0001-01-01T00:09:21+00:09 | block:basic-sec-captcha | ["::CAPTCHA_BOX::"]                |
| 88e09f3f4e8e0ecd429df624f9746a1c | test.com                     | 500_errors        | 5XX Errors                   | default | <null> | 0001-01-01T00:09:21+00:09 | 0001-01-01T00:09:21+00:09 | cf-error:500s           | ["::CLOUDFLARE_ERROR_500S_BOX::"]  |
| 88e09f3f4e8e0ecd429df624f9746a1c | test.com                     | waf_challenge     | WAF Challenge                | default | <null> | 0001-01-01T00:09:21+00:09 | 0001-01-01T00:09:21+00:09 | block:adv-sec-captcha   | ["::CAPTCHA_BOX::"]                |
| 88e09f3f4e8e0ecd429df624f9746a1c | test.com                     | waf_block         | WAF Block                    | default | <null> | 0001-01-01T00:09:21+00:09 | 0001-01-01T00:09:21+00:09 | block:waf               | <null>                             |
| 88e09f3f4e8e0ecd429df624f9746a1c | test.com                     | ratelimit_block   | Rate limit Block             | default | <null> | 0001-01-01T00:09:21+00:09 | 0001-01-01T00:09:21+00:09 | block:rate-limit        | <null>                             |
| 88e09f3f4e8e0ecd429df624f9746a1c | test.com                     | ip_block          | IP or IP range block         | default | <null> | 0001-01-01T00:09:21+00:09 | 0001-01-01T00:09:21+00:09 | block:ip-ban            | <null>                             |
| 88e09f3f4e8e0ecd429df624f9746a1c | test.com                     | managed_challenge | Cloudflare Managed Challenge | default | <null> | 0001-01-01T00:09:21+00:09 | 0001-01-01T00:09:21+00:09 | block:managed-challenge | ["::CAPTCHA_BOX::"]                |
+----------------------------------+------------------------------+-------------------+------------------------------+---------+--------+---------------------------+---------------------------+-------------------------+------------------------------------+

```

</details>
