### PR TITLE
Optimize cloudflare_zone_settings table performance to fetch zone settings and handling rate limits Closes #172

### DIFF
--- a/cloudflare/plugin.go
+++ b/cloudflare/plugin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v5/rate_limiter"
 )
 
 func Plugin(ctx context.Context) *plugin.Plugin {
@@ -12,6 +13,17 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 		Name: "steampipe-plugin-cloudflare",
 		ConnectionConfigSchema: &plugin.ConnectionConfigSchema{
 			NewInstance: ConfigInstance,
+		},
+		
+		// https://developers.cloudflare.com/fundamentals/api/reference/limits/
+		// The Cloudflare API has a rate limit 1200/5 minutes - Client API per user
+		RateLimiters: []*rate_limiter.Definition{
+			{
+				Name:           "cloudflare_api",
+				FillRate:       60,
+				BucketSize:     60,
+				MaxConcurrency: 60,
+			},
 		},
 		ConnectionKeyColumns: []plugin.ConnectionKeyColumn{
 			{

--- a/cloudflare/table_cloudflare_zone_setting.go
+++ b/cloudflare/table_cloudflare_zone_setting.go
@@ -3,16 +3,13 @@ package cloudflare
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"strings"
-	"sync"
+	"fmt"
 
 	"github.com/cloudflare/cloudflare-go/v4"
 	"github.com/cloudflare/cloudflare-go/v4/zones"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
-	"github.com/turbot/steampipe-plugin-sdk/v5/query_cache"
 )
 
 func tableCloudflareZoneSetting(ctx context.Context) *plugin.Table {
@@ -25,13 +22,15 @@ func tableCloudflareZoneSetting(ctx context.Context) *plugin.Table {
 			KeyColumns: plugin.KeyColumnSlice{
 				{Name: "zone_id", Require: plugin.Optional},
 				{Name: "id", Require: plugin.Optional},
-				{Name: "ids", Require: plugin.Optional, CacheMatch: query_cache.CacheMatchExact},
 			},
+		},
+		Get: &plugin.GetConfig{
+			Hydrate:    getZoneSetting,
+			KeyColumns: plugin.AllColumns([]string{"zone_id", "id"}),
 		},
 		Columns: commonColumns([]*plugin.Column{
 			// Top columns
 			{Name: "id", Type: proto.ColumnType_STRING, Transform: transform.FromField("ID"), Description: "The ID of the zone setting."},
-			{Name: "ids", Type: proto.ColumnType_JSON, Transform: transform.FromQual("ids"), Description: "The IDs of the zone setting."},
 			{Name: "zone_id", Type: proto.ColumnType_STRING, Transform: transform.FromField("ZoneID"), Description: "Zone identifier."},
 
 			// The value field from the API response may have string or JSON property.
@@ -43,7 +42,7 @@ func tableCloudflareZoneSetting(ctx context.Context) *plugin.Table {
 			// Other columns
 			{Name: "editable", Type: proto.ColumnType_BOOL, Transform: transform.From(transformEditable), Description: "Whether the setting is editable."},
 			{Name: "enabled", Type: proto.ColumnType_BOOL, Description: "SSL-recommender enrollment setting."},
-			{Name: "modified_on", Type: proto.ColumnType_TIMESTAMP, Description: "When the setting was last modified."},
+			{Name: "modified_on", Type: proto.ColumnType_TIMESTAMP, Transform: transform.From(transformModifiedOn), Description: "When the setting was last modified."},
 		}),
 	}
 }
@@ -63,95 +62,10 @@ func listZoneSettings(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		return nil, nil
 	}
 
-	// Check if specific setting is requested
-	inputSettingId := d.EqualsQualString("id")
-	inputSettingIds := d.EqualsQuals["ids"].GetJsonbValue()
-
-	// Available zone setting IDs
-	settingIds := []string{
-		"aegis", "0rtt", "advanced_ddos", "always_online", "always_use_https", "automatic_https_rewrites",
-		"brotli", "browser_cache_ttl", "browser_check", "cache_level", "challenge_ttl",
-		"ciphers", "cname_flattening", "development_mode", "early_hints", "edge_cache_ttl",
-		"email_obfuscation", "h2_prioritization", "hotlink_protection", "http2", "http3",
-		"image_resizing", "ip_geolocation", "ipv6", "max_upload", "min_tls_version",
-		"mirage", "nel", "opportunistic_encryption", "opportunistic_onion", "orange_to_orange",
-		"origin_error_page_pass_thru", "origin_h2_max_streams", "origin_max_http_version",
-		"polish", "prefetch_preload", "privacy_pass", "proxy_read_timeout", "pseudo_ipv4",
-		"replace_insecure_js", "response_buffering", "rocket_loader", "automatic_platform_optimization",
-		"security_header", "security_level", "server_side_exclude", "sha1_support",
-		"sort_query_string_for_cache", "ssl", "ssl_recommender", "tls_1_2_only", "tls_1_3",
-		"tls_client_auth", "true_client_ip_header", "waf", "webp", "websockets",
-	}
-
-	// If specific setting ID is requested, only query that one
-	if inputSettingId != "" {
-		settingIds = []string{inputSettingId}
-	}
-
-	if inputSettingIds != "" {
-		var ids []string
-		err := json.Unmarshal([]byte(inputSettingIds), &ids)
-		if err != nil {
-			return nil, errors.New("unable to parse the 'ids' query parameter the value must be in the format '[\"http2\", \"ssl\"]'")
-		}
-		settingIds = ids
-	}
-
-	conn, err := connectV4(ctx, d)
+	allSettings, err := ListAllZoneSettings(ctx, d, zone.ID)
 	if err != nil {
-		logger.Error("cloudflare_zone_setting.listZoneSettings", "connection error", err)
+		logger.Error("cloudflare_zone_setting.listZoneSettings", "error listing zone settings", err)
 		return nil, err
-	}
-
-	// Process settings in batches of 10 with parallel API calls
-	// This is to avoid rate limiting by Cloudflare and optimize the query timing
-	batchSize := 10
-	var allSettings []ZoneSettingInfo
-
-	for i := 0; i < len(settingIds); i += batchSize {
-		end := i + batchSize
-		if end > len(settingIds) {
-			end = len(settingIds)
-		}
-
-		batch := settingIds[i:end]
-		var wg sync.WaitGroup
-		var mu sync.Mutex
-		var batchSettings []ZoneSettingInfo
-
-		for _, settingId := range batch {
-			wg.Add(1)
-			go func(sid string) {
-				defer wg.Done()
-
-				item, err := conn.Zones.Settings.Get(ctx, sid, zones.SettingGetParams{ZoneID: cloudflare.F(zone.ID)})
-				if err != nil {
-					// Some settings might not be available for all zones
-					if strings.Contains(err.Error(), "Undefined zone setting") {
-						return
-					}
-					if strings.Contains(err.Error(), "Access denied") {
-						return
-					}
-					logger.Error("cloudflare_zone_setting.listZoneSettings", "ZoneSetting api error", err)
-					return
-				}
-
-				setting := ZoneSettingInfo{zone.ID, *item}
-
-				mu.Lock()
-				batchSettings = append(batchSettings, setting)
-				mu.Unlock()
-			}(settingId)
-		}
-
-		wg.Wait()
-		allSettings = append(allSettings, batchSettings...)
-
-		// Check if context is cancelled or limit reached
-		if d.RowsRemaining(ctx) == 0 {
-			break
-		}
 	}
 
 	// Stream all collected settings
@@ -167,6 +81,35 @@ func listZoneSettings(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	return nil, nil
 }
 
+func getZoneSetting(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+
+	// Get zone_id and setting id from key columns
+	zoneID := d.EqualsQualString("zone_id")
+	settingID := d.EqualsQualString("id")
+
+	// Get authenticated client using connectV4
+	conn, err := connectV4(ctx, d)
+	if err != nil {
+		logger.Error("cloudflare_zone_setting.getZoneSetting", "connection error", err)
+		return nil, err
+	}
+
+	// Use the SDK function to get individual zone setting
+	item, err := conn.Zones.Settings.Get(ctx, settingID, zones.SettingGetParams{ZoneID: cloudflare.F(zoneID)})
+	if err != nil {
+		logger.Error("cloudflare_zone_setting.getZoneSetting", "API error", err)
+		return nil, err
+	}
+
+	setting := ZoneSettingInfo{
+		ZoneID:             zoneID,
+		SettingGetResponse: *item,
+	}
+
+	return setting, nil
+}
+
 //// TRANSFORM FUNCTIONS
 
 func transformEditable(ctx context.Context, d *transform.TransformData) (interface{}, error) {
@@ -175,4 +118,72 @@ func transformEditable(ctx context.Context, d *transform.TransformData) (interfa
 		return true, nil
 	}
 	return false, nil
+}
+
+func transformModifiedOn(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	modifiedOn := d.HydrateItem.(ZoneSettingInfo).ModifiedOn
+
+	// Check if the time is zero/null (default Go time value or Unix epoch)
+	if modifiedOn.IsZero() || modifiedOn.Unix() <= 0 {
+		return nil, nil
+	}
+
+	// Check for the specific problematic timestamp pattern (year 0001)
+	if modifiedOn.Year() <= 1 {
+		return nil, nil
+	}
+
+	return modifiedOn, nil
+}
+
+//// API call
+
+// ListZoneSettings makes a GET request to https://api.cloudflare.com/client/v4/zones/$ZONE_ID/settings
+// As per the API doc(https://developers.cloudflare.com/api/resources/zones/subresources/settings/methods/list/) it is mentioned that the endpoint is DEPRECATED
+// However, in deprecation API doc(https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#2025-06-08) the endpoint is not DEPRECATED it is AFFECTED by a single setting "cname_flattening".
+func ListAllZoneSettings(ctx context.Context, d *plugin.QueryData, zoneID string) ([]ZoneSettingInfo, error) {
+	logger := plugin.Logger(ctx)
+
+	// Get authenticated client using connectV4
+	conn, err := connectV4(ctx, d)
+	if err != nil {
+		logger.Error("cloudflare_zone_setting.ListAllZoneSettings", "connection error", err)
+		return nil, err
+	}
+
+	// Build the path for the API call
+	path := fmt.Sprintf("zones/%s/settings", zoneID)
+
+	// Define response structure
+	var apiResponse struct {
+		Success bool                     `json:"success"`
+		Errors  []map[string]interface{} `json:"errors"`
+		Result  []json.RawMessage        `json:"result"`
+	}
+
+	// Make the GET request using the client
+	err = conn.Get(ctx, path, nil, &apiResponse)
+	if err != nil {
+		logger.Error("cloudflare_zone_setting.ListZoneSettings", "API request error", err)
+		return nil, fmt.Errorf("failed to get zone settings: %w", err)
+	}
+
+	if !apiResponse.Success {
+		return nil, fmt.Errorf("API request failed: %v", apiResponse.Errors)
+	}
+
+	// Process each setting from the result
+	var settings []ZoneSettingInfo
+	for _, rawSetting := range apiResponse.Result {
+		// Parse each setting as a zones.SettingGetResponse
+		var settingResponse zones.SettingGetResponse
+		if err := json.Unmarshal(rawSetting, &settingResponse); err != nil {
+			logger.Warn("cloudflare_zone_setting.ListZoneSettings", "failed to parse setting", err, "raw_data", string(rawSetting))
+			continue
+		}
+
+		settings = append(settings, ZoneSettingInfo{zoneID, settingResponse})
+	}
+
+	return settings, nil
 }

--- a/docs/tables/cloudflare_zone_setting.md
+++ b/docs/tables/cloudflare_zone_setting.md
@@ -14,7 +14,6 @@ The `cloudflare_zone_setting` table provides insights into individual zone setti
 **Important Notes:**
 - By default this table fetches all settings across all zones.
 - For optimal performance and to reduce query time, always specify `zone_id` and/or `id` (setting ID) in your WHERE clause.
-- Use `ids` column to query multiple specific settings efficiently by providing a JSON array of setting IDs.
 - Possible values for `id` are:
   - `aegis`
   - `0rtt`
@@ -241,41 +240,6 @@ where
   zs.id = 'development_mode'
 order by
   z.name;
-```
-
-### Query multiple settings with zone comparison
-Compare multiple settings across zones efficiently using the `ids` column.
-
-```sql+postgres
-select
-  z.name as zone_name,
-  z.type as zone_type,
-  zs.id as setting_id,
-  zs.value,
-  zs.editable
-from
-  cloudflare_zone_setting zs
-  join cloudflare_zone z on zs.zone_id = z.id
-where
-  zs.ids = '["development_mode", "ssl", "security_level"]'
-order by
-  z.name, zs.id;
-```
-
-```sql+sqlite
-select
-  z.name as zone_name,
-  z.type as zone_type,
-  zs.id as setting_id,
-  zs.value,
-  zs.editable
-from
-  cloudflare_zone_setting zs
-  join cloudflare_zone z on zs.zone_id = z.id
-where
-  zs.ids = '["development_mode", "ssl", "security_level"]'
-order by
-  z.name, zs.id;
 ```
 
 ### List editable vs non-editable settings summary


### PR DESCRIPTION

# Example query results

<details>
  <summary>Results</summary>

```
> select * from cloudflare_zone_setting
+-----------------------------+----------------------------------+-------------------------------------------------------------------------------------->
| id                          | zone_id                          | value                                                                                >
+-----------------------------+----------------------------------+-------------------------------------------------------------------------------------->
| max_upload                  | e19325207280c0050614b7b83d29a2ff | 100                                                                                  >
| pseudo_ipv4                 | e19325207280c0050614b7b83d29a2ff | off                                                                                  >
| max_upload                  | e19325207280c0050614b7b83d29a2ff | 100                                                                                  >
| replace_insecure_js         | e19325207280c0050614b7b83d29a2ff | on                                                                                   >
| ech                         | e19325207280c0050614b7b83d29a2ff | on                                                                                   >
| ipv6                        | e19325207280c0050614b7b83d29a2ff | on                                                                                   >
| browser_cache_ttl           | e19325207280c0050614b7b83d29a2ff | 14400                                                                                >
| ssl                         | e19325207280c0050614b7b83d29a2ff | full                                                                                 >
| min_tls_version             | e19325207280c0050614b7b83d29a2ff | 1.0                                                                                  >
| early_hints                 | e19325207280c0050614b7b83d29a2ff | off                                                                                  >
| filter_logs_to_cloudflare   | e19325207280c0050614b7b83d29a2ff | off                                                                                  >
| always_online               | e19325207280c0050614b7b83d29a2ff | off                                                                                  >
| minify                      | e19325207280c0050614b7b83d29a2ff | {"css":"off","html":"off","js":"off"}                                                >
| long_lived_grpc             | e19325207280c0050614b7b83d29a2ff | off                                                                                  >
| sort_query_string_for_cache | e19325207280c0050614b7b83d29a2ff | off                                                                                  >
| tls_1_3                     | e19325207280c0050614b7b83d29a2ff | on                                                                                   >
| privacy_pass                | e19325207280c0050614b7b83d29a2ff | on                                                                                   >
| min_tls_version             | e19325207280c0050614b7b83d29a2ff | 1.0                                                                                  >
| log_to_cloudflare           | e19325207280c0050614b7b83d29a2ff | on                                                                                   >
| development_mode            | e19325207280c0050614b7b83d29a2ff | off                                                                                  >
| hotlink_protection          | e19325207280c0050614b7b83d29a2ff | off                                                                                  >
| ech                         | e19325207280c0050614b7b83d29a2ff | on                                                                                   >
| 0rtt                        | e19325207280c0050614b7b83d29a2ff | off                                                                                  >
| ip_geolocation              | e19325207280c0050614b7b83d29a2ff | on                                                                                   >
| cache_level                 | e19325207280c0050614b7b83d29a2ff | aggressive                                                                           >
| mobile_redirect             | e19325207280c0050614b7b83d29a2ff | {"status":"off","mobile_subdomain":null,"strip_uri":false}                           >
| tls_1_2_only                | e19325207280c0050614b7b83d29a2ff | off                                                                                  >
16,856 rows (10,000 shown)

Time: 286.4s. Rows returned: 16,856. Rows fetched: 16,856. Hydrate calls: 16,856.

Scans:
  1) cloudflare_zone_setting.cloudflare: Time: 286.3s. Fetched: 16,856. Hydrates: 16,856.
```

</details>
