### PR TITLE
feat: add cloudflare_custom_certificate table

### DIFF
--- a/cloudflare/plugin.go
+++ b/cloudflare/plugin.go
@@ -43,6 +43,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"cloudflare_worker_route":          tableCloudflareWorkerRoute(ctx),
 			"cloudflare_zone":                  tableCloudflareZone(ctx),
 			"cloudflare_zone_setting":          tableCloudflareZoneSetting(ctx),
+			"cloudflare_custom_certificate":    tableCloudflareCustomCertificate(ctx),
 		},
 	}
 	return p

--- a/cloudflare/table_cloudflare_custom_certificate.go
+++ b/cloudflare/table_cloudflare_custom_certificate.go
@@ -1,0 +1,154 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go/v4"
+	"github.com/cloudflare/cloudflare-go/v4/custom_certificates"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableCloudflareCustomCertificate(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "cloudflare_custom_certificate",
+		Description: "Custom certificates are meant for Business and Enterprise customers who want to use their own SSL certificates.",
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "zone_id", Require: plugin.Required},
+			},
+			Hydrate: listCustomCertificates,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "id", Require: plugin.Required},
+				{Name: "zone_id", Require: plugin.Required},
+			},
+			ShouldIgnoreError: isNotFoundError([]string{"Invalid custom certificate identifier"}),
+			Hydrate:           getCustomCertificate,
+		},
+		Columns: commonColumns([]*plugin.Column{
+			// Top columns
+			{Name: "id", Type: proto.ColumnType_STRING, Transform: transform.FromField("ID"), Description: "Custom certificate identifier."},
+			{Name: "bundle_method", Type: proto.ColumnType_STRING, Description: "Custom certificate identifier."},
+			{Name: "expires_on", Type: proto.ColumnType_TIMESTAMP,  Description: "When the certificate from the authority expires."},
+			{Name: "hosts", Type: proto.ColumnType_STRING, Description: "The domain names covered by the custom certificate."},
+			{Name: "issuer", Type: proto.ColumnType_STRING, Description: "The certificate authority that issued the certificate."},
+			{Name: "modified_on", Type: proto.ColumnType_TIMESTAMP, Description: "When the certificate was last modified."},
+			{Name: "priority", Type: proto.ColumnType_STRING, Description: "The order/priority in which the certificate will be used in a request."},
+			{Name: "signature", Type: proto.ColumnType_STRING, Description: "The type of hash used for the certificate."},
+			{Name: "status", Type: proto.ColumnType_STRING, Description: "Status of the zone's custom SSL."},
+			{Name: "uploaded_on", Type: proto.ColumnType_TIMESTAMP, Description: "When the certificate was uploaded to Cloudflare."},
+			{Name: "geo_restrictions", Type: proto.ColumnType_STRING,Transform: transform.From(transformGeoRestrictions), Description: "Specify the region where your private key can be held locally for optimal TLS performance."},
+			{Name: "policy", Type: proto.ColumnType_STRING, Description: "Specify the policy that determines the region where your private key will be held locally."},
+			
+			// Query columns for filtering
+			{Name: "zone_id", Type: proto.ColumnType_STRING, Transform: transform.FromField("ZoneID"), Description: "The zone ID to filter custom certificates."},
+		
+			// JSON Columns
+			{Name: "keyless_server", Type: proto.ColumnType_JSON, Description: "Keyless certificate details."},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+// listCustomCertificates retrieves all custom certificates for the specified zone_id.
+func listCustomCertificates(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	conn, err := connectV4(ctx, d)
+	if err != nil {
+		logger.Error("cloudflare_custom_certificate.listCustomCertificates", "connection_error", err)
+		return nil, err
+	}
+
+	// Get the qualifiers
+	quals := d.EqualsQuals
+	zoneID := quals["zone_id"].GetStringValue()
+
+	// Empty check
+	if zoneID == "" {
+		return nil, nil
+	}
+
+	// Build API parameters
+	input := custom_certificates.CustomCertificateListParams{
+		ZoneID: cloudflare.F(zoneID),
+	}
+
+	// Execute paginated API call
+	iter := conn.CustomCertificates.ListAutoPaging(ctx, input)
+	for iter.Next() {
+		customCertificate := iter.Current()
+		d.StreamListItem(ctx, customCertificate)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
+	}
+	if err := iter.Err(); err != nil {
+		// Custom certificates are not available for all plan levels.
+		if strings.Contains(err.Error(), "Plan level does not allow custom certificates") {
+			return nil, nil
+		}
+		logger.Error("cloudflare_custom_certificate.listCustomCertificates", "ListAutoPaging error", err)
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+//// GET FUNCTION
+
+// getCustomCertificate retrieves a specific custom certificate by ID.
+//
+// Parameters:
+// - id: The custom certificate identifier (required)
+// - zone_id: The account or zone context (required)
+func getCustomCertificate(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	conn, err := connectV4(ctx, d)
+	if err != nil {
+		logger.Error("cloudflare_custom_certificate.getCustomCertificate", "connection_error", err)
+		return nil, err
+	}
+
+	quals := d.EqualsQuals
+	customCertificateID := quals["id"].GetStringValue()
+	zoneID := quals["zone_id"].GetStringValue()
+
+	input := custom_certificates.CustomCertificateGetParams{
+		ZoneID: cloudflare.F(zoneID),
+	}
+
+	// Execute API call to get the specific custom certificate
+	ruleset, err := conn.CustomCertificates.Get(ctx, customCertificateID, input)
+	if err != nil {
+		logger.Error("cloudflare_custom_certificate.getCustomCertificate", "error", err)
+		return nil, err
+	}
+
+	return ruleset, nil
+}
+
+//// TRANSFORM FUNCTIONS
+
+func transformGeoRestrictions(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+    switch customCertificate := d.HydrateItem.(type) {
+    case custom_certificates.CustomCertificate:
+        return string(customCertificate.GeoRestrictions.Label), nil
+    case *custom_certificates.CustomCertificate:
+        if customCertificate == nil {
+            return nil, nil
+        }
+        return string(customCertificate.GeoRestrictions.Label), nil
+    default:
+        return nil, fmt.Errorf("unexpected type: %T", d.HydrateItem)
+    }
+}

--- a/docs/tables/cloudflare_custom_certificate.md
+++ b/docs/tables/cloudflare_custom_certificate.md
@@ -1,0 +1,141 @@
+---
+title: "Steampipe Table: cloudflare_custom_certificate - Query Cloudflare Custom Certificates using SQL"
+description: "Allows users to query Custom Certificates in Cloudflare, offering visibility into user-managed SSL/TLS certificates for Business and Enterprise plans, covering details such as hosts, issuer, expiration, upload and modification timestamps, bundle method, priority, status, and geo-key policies at the zone level."
+---
+
+# Table: cloudflare_custom_certificate - Query Cloudflare Custom Certificates using SQL
+
+Custom Certificates allow Business and Enterprise customers to bring and manage their own SSL/TLS certificates within Cloudflare. These user‑provided certificates require manual lifecycle management—uploading, renewing, and monitoring expiration. Cloudflare organizes them into certificate packs (covering multiple signature algorithms per hostname group), and supports geo‑key restriction for private key locality.
+
+## Table Usage Guide
+
+The `cloudflare_custom_certificate` table provides insights into user-managed SSL/TLS certificates within Cloudflare. As a security administrator or DevOps engineer, you can explore certificate-specific details through this table, including hosts, issuer, expiration, upload and modification timestamps, bundle method, priority, status, and geo-key policy configurations—all scoped at the zone level. Leverage it to audit custom certificate deployments, monitor expiration lifecycles, manage overlapping certificate priorities, and enforce geo‑restriction policies across your Cloudflare infrastructure.
+
+**Important Notes**
+- You must specify a `zone_id` in a `where` or `join` clause to query this table.
+
+## Examples
+
+### Query all custom certificates for a zone
+```sql+postgres
+select
+  id,
+  hosts,
+  issuer,
+  status,
+  expires_on
+from
+  cloudflare_custom_certificate
+where
+  zone_id = 'YOUR_ZONE_ID';
+```
+
+```sql+sqlite
+select
+  id,
+  hosts,
+  issuer,
+  status,
+  expires_on
+from
+  cloudflare_custom_certificate
+where
+  zone_id = 'YOUR_ZONE_ID';
+```
+
+### Get a specific custom certificate by its ID
+```sql+postgres
+select
+  id,
+  hosts,
+  bundle_method,
+  priority,
+  uploaded_on,
+  modified_on,
+  geo_restrictions,
+  policy
+from
+  cloudflare_custom_certificate
+where
+  zone_id = 'YOUR_ZONE_ID'
+  and id      = 'CERTIFICATE_ID';
+```
+
+```sql+sqlite
+select
+  id,
+  hosts,
+  bundle_method,
+  priority,
+  uploaded_on,
+  modified_on,
+  geo_restrictions,
+  policy
+from
+  cloudflare_custom_certificate
+where
+  zone_id = 'YOUR_ZONE_ID'
+  and id      = 'CERTIFICATE_ID';
+```
+
+### Query all custom certificates expiring in the next 30 days for a zone
+```sql+postgres
+select
+  id,
+  hosts,
+  issuer,
+  expires_on
+from
+  cloudflare_custom_certificate
+where
+  zone_id = 'YOUR_ZONE_ID'
+  and expires_on < now() + interval '30 days'
+order by
+  expires_on;
+```
+
+```sql+sqlite
+select
+  id,
+  hosts,
+  issuer,
+  expires_on
+from
+  cloudflare_custom_certificate
+where
+  zone_id = 'YOUR_ZONE_ID'
+  and expires_on < now() + interval '30 days'
+order by
+  expires_on;
+```
+
+### Order the custom certificates for a zone by priority
+```sql+postgres
+select
+  id,
+  hosts,
+  issuer,
+  priority,
+  status
+from
+  cloudflare_custom_certificate
+where
+  zone_id = 'YOUR_ZONE_ID'
+order by
+  priority::integer asc;
+```
+
+```sql+sqlite
+select
+  id,
+  hosts,
+  issuer,
+  priority,
+  status
+from
+  cloudflare_custom_certificate
+where
+  zone_id = 'YOUR_ZONE_ID'
+order by
+  priority::integer asc;
+```


### PR DESCRIPTION
# Example query results

<details>
  <summary>Results</summary>

```
SELECT 
  z.id as zone_id, 
  z.name as zone_name, 
  c.id, 
  c.bundle_method, 
  c.expires_on, 
  c.hosts, 
  c.issuer, 
  c.modified_on, 
  c.priority, 
  c.signature, 
  c.status, 
  c.uploaded_on, 
  c.geo_restrictions, 
  c.policy, 
  c.keyless_server 
FROM 
  cloudflare_custom_certificate as c 
JOIN 
  cloudflare_zone as z 
ON 
  c.zone_id = z.id
+----------------------------------+-------------------+--------------------------------------+---------------+---------------------+-------------------------------------+--------+---------------------+----------+---------------+--------+---------------------+------------------+-----------------------------+------------------------------------------+
| zone_id                          | zone_name         | id                                   | bundle_method | expires_on          | hosts                               | issuer | modified_on         | priority | signature     | status | uploaded_on         | geo_restrictions | policy                      | keyless_server                          |
+----------------------------------+-------------------+--------------------------------------+---------------+---------------------+-------------------------------------+--------+---------------------+----------+---------------+--------+---------------------+------------------+-----------------------------+------------------------------------------+
| 123e4567e89b12d3a456426614174000 | test-domain-01.com|  1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p|  ubiquitous   | 2025-12-26T00:59:59 | [*.test-domain-01.com               | TestCA | 2024-12-09T14:50:08 | 0        | SHA384WithRSA | active | 2024-12-09T14:36:17 | us               | (country: US) or            | {"created_on": "0001-01-01T00:00:00Z", |
|                                  |                   |                                      |               |                     |  test-domain-01.com]                |        |                     |          |               |        |                     |                  | (region: EU)                |  "enabled": false,                     |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "host": "",                           |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "id": "",                             |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "modified_on": "0001-01-01T00:00:00Z",|
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "name": "",                           |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "permissions": null,                  |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "port": 0,                            |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "status": "",                         |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "tunnel": {"private_ip": "",          |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "vnet_id": ""}}                       |
| 223e4567e89b12d3a456426614174001 | test-domain-02.com | 2b3c4d5e-6f7g-8h9i-0j1k-2l3m4n5o6p7q| ubiquitous    | 2026-04-16T01:59:59 | [*.test-domain-02.com               | TestCA | 2025-03-19T16:50:28 | 0        | SHA384WithRSA | active | 2025-03-19T16:40:26 | us               | (country: US) or            | {"created_on": "0001-01-01T00:00:00Z", |
|                                  |                   |                                      |               |                     |  test-domain-02.com]                |        |                     |          |               |        |                     |                  | (region: EU)                |  "enabled": false,                     |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "host": "",                           |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "id": "",                             |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "modified_on": "0001-01-01T00:00:00Z",|
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "name": "",                           |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "permissions": null,                  |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "port": 0,                            |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "status": "",                         |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "tunnel": {"private_ip": "",          |
|                                  |                   |                                      |               |                     |                                     |        |                     |          |               |        |                     |                  |                             |  "vnet_id": ""}}                       |
+----------------------------------+-------------------+--------------------------------------+---------------+---------------------+-------------------------------------+--------+---------------------+----------+---------------+--------+---------------------+------------------+-----------------------------+------------------------------------------+
```

</details>
