### PR TITLE
feat: add cloudflare_managed_transforms table

### DIFF
--- a/cloudflare/plugin.go
+++ b/cloudflare/plugin.go
@@ -37,6 +37,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"cloudflare_load_balancer_monitor": tableCloudflareLoadBalancerMonitor(ctx),
 			"cloudflare_load_balancer_pool":    tableCloudflareLoadBalancerPool(ctx),
 			"cloudflare_logpush_job":           tableCloudflareLogpushJob(ctx),
+			"cloudflare_managed_transforms":    tableCloudflareManagedTransforms(ctx),
 			"cloudflare_notification_policy":   tableCloudflareNotificationPolicy(ctx),
 			"cloudflare_page_rule":             tableCloudflarePageRule(ctx),
 			"cloudflare_r2_bucket":             tableCloudflareR2Bucket(ctx),

--- a/cloudflare/table_cloudflare_managed_transforms.go
+++ b/cloudflare/table_cloudflare_managed_transforms.go
@@ -1,0 +1,120 @@
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/cloudflare/cloudflare-go/v4"
+	"github.com/cloudflare/cloudflare-go/v4/managed_transforms"
+	"github.com/cloudflare/cloudflare-go/v4/zones"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableCloudflareManagedTransforms(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "cloudflare_managed_transforms",
+		Description: "Managed Transforms allow you to perform common adjustments to HTTP request and response headers with the click of a button.",
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "zone_id", Require: plugin.Optional},
+			},
+			Hydrate: listManagedTransforms,
+			ParentHydrate: listZones,
+		},
+		Columns: commonColumns([]*plugin.Column{
+			// Top columns
+			{Name: "id", Type: proto.ColumnType_STRING, Transform: transform.FromField("ID"), Description: "The human-readable identifier of the Managed Transform."},
+			{Name: "type", Type: proto.ColumnType_STRING, Description: "The type of Managed Transform: 'request_header' or 'response_header'."},
+			{Name: "enabled", Type: proto.ColumnType_BOOL, Description: "Whether the Managed Transform is enabled."},
+			{Name: "has_conflict", Type: proto.ColumnType_BOOL, Description: "Whether the Managed Transform conflicts with the currently-enabled Managed Transforms."},
+			
+			// Other columns
+			{Name: "zone_id", Type: proto.ColumnType_STRING, Transform: transform.FromField("ZoneID"), Description: "The zone ID."},
+			
+			// JSON Columns
+			{Name: "conflicts_with", Type: proto.ColumnType_JSON, Description: "The Managed Transforms that this Managed Transform conflicts with."},
+		}),
+	}
+}
+
+type ManagedTransformInfo struct {
+	ID            string
+	Type          string
+	Enabled       bool
+	HasConflict   bool
+	ConflictsWith []string
+	ZoneID        string
+}
+
+//// LIST FUNCTION
+
+// listManagedTransforms retrieves all managed transforms.
+func listManagedTransforms(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	zoneDetails := h.Item.(zones.Zone)
+	inputZoneId := d.EqualsQualString("zone_id")
+
+	logger := plugin.Logger(ctx)
+	conn, err := connectV4(ctx, d)
+	if err != nil {
+		logger.Error("cloudflare_managed_transforms.listManagedTransforms", "connection_error", err)
+		return nil, err
+	}
+
+	// Only list managed transforms for zones stated in the input query
+	if inputZoneId != "" && inputZoneId != zoneDetails.ID {
+		return nil, nil
+	}
+
+	// Build API parameters
+	input := managed_transforms.ManagedTransformListParams{
+		ZoneID: cloudflare.F(zoneDetails.ID),
+	}
+
+	// Execute API call (this is a GET operation that returns both lists)
+	response, err := conn.ManagedTransforms.List(ctx, input)
+	if err != nil {
+		logger.Error("cloudflare_managed_transforms.listManagedTransforms", "api_error", err)
+		return nil, err
+	}
+
+	// Process managed request headers
+	for _, requestHeader := range response.ManagedRequestHeaders {
+		transform := ManagedTransformInfo{
+			ID:            requestHeader.ID,
+			Type:          "request_header",
+			Enabled:       requestHeader.Enabled,
+			HasConflict:   requestHeader.HasConflict,
+			ConflictsWith: requestHeader.ConflictsWith,
+			ZoneID:        zoneDetails.ID,
+		}
+		d.StreamListItem(ctx, transform)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
+	}
+
+	// Process managed response headers
+	for _, responseHeader := range response.ManagedResponseHeaders {
+		transform := ManagedTransformInfo{
+			ID:            responseHeader.ID,
+			Type:          "response_header",
+			Enabled:       responseHeader.Enabled,
+			HasConflict:   responseHeader.HasConflict,
+			ConflictsWith: responseHeader.ConflictsWith,
+			ZoneID:        zoneDetails.ID,
+		}
+		d.StreamListItem(ctx, transform)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/docs/tables/cloudflare_managed_transforms.md
+++ b/docs/tables/cloudflare_managed_transforms.md
@@ -1,0 +1,227 @@
+---
+title: "Steampipe Table: cloudflare_managed_transforms - Query Cloudflare Managed Transforms using SQL"
+description: "Allows users to query Cloudflare Managed Transforms, surfacing configuration for HTTP request and response header modifications including transform ID, type, enabled status, conflict detection, and associated zone information."
+---
+
+# Table: cloudflare_managed_transforms - Query Cloudflare Managed Transforms using SQL
+
+Managed Transforms allow you to perform common adjustments to HTTP request and response headers with the click of a button. These pre-configured transforms help standardize header handling across your zones without requiring custom rules.
+
+## Table Usage Guide
+
+The `cloudflare_managed_transforms` table provides insights into managed transform configurations per zone within Cloudflare. As a security administrator or DevOps engineer, you can explore transform ID, type (request or response header), enabled status, conflict detection flags, and the list of conflicting transforms. Use it to audit active header modifications, detect configuration conflicts, and verify transform settings across zones.
+
+## Examples
+
+### Query all managed transforms for a zone
+Retrieves all managed transforms associated with a specific zone ID. Managed transforms are used to modify HTTP request and response headers automatically.
+
+```sql+postgres
+select
+  mt.id,
+  mt.type,
+  mt.enabled,
+  mt.has_conflict,
+  z.name as zone_name
+from
+  cloudflare_managed_transforms mt
+join
+  cloudflare_zone z
+on
+  mt.zone_id = z.id
+where
+  mt.zone_id = 'YOUR_ZONE_ID';
+```
+
+```sql+sqlite
+select
+  mt.id,
+  mt.type,
+  mt.enabled,
+  mt.has_conflict,
+  z.name as zone_name
+from
+  cloudflare_managed_transforms mt
+join
+  cloudflare_zone z
+on
+  mt.zone_id = z.id
+where
+  mt.zone_id = 'YOUR_ZONE_ID';
+```
+
+### Query all enabled managed transforms
+Retrieves all enabled managed transforms across all zones. This is useful for understanding which header modifications are currently active.
+
+```sql+postgres
+select
+  mt.id,
+  mt.type,
+  mt.enabled,
+  z.name as zone_name
+from
+  cloudflare_managed_transforms mt
+join
+  cloudflare_zone z
+on
+  mt.zone_id = z.id
+where
+  mt.enabled = true;
+```
+
+```sql+sqlite
+select
+  mt.id,
+  mt.type,
+  mt.enabled,
+  z.name as zone_name
+from
+  cloudflare_managed_transforms mt
+join
+  cloudflare_zone z
+on
+  mt.zone_id = z.id
+where
+  mt.enabled = true;
+```
+
+### Query all managed transforms with conflicts
+Retrieves all managed transforms that have conflicts with other transforms. This helps identify configuration issues that may need resolution.
+
+```sql+postgres
+select
+  mt.id,
+  mt.type,
+  mt.enabled,
+  mt.has_conflict,
+  mt.conflicts_with,
+  z.name as zone_name
+from
+  cloudflare_managed_transforms mt
+join
+  cloudflare_zone z
+on
+  mt.zone_id = z.id
+where
+  mt.has_conflict = true;
+```
+
+```sql+sqlite
+select
+  mt.id,
+  mt.type,
+  mt.enabled,
+  mt.has_conflict,
+  mt.conflicts_with,
+  z.name as zone_name
+from
+  cloudflare_managed_transforms mt
+join
+  cloudflare_zone z
+on
+  mt.zone_id = z.id
+where
+  mt.has_conflict = true;
+```
+
+### Query all request header transforms
+Retrieves all managed transforms that modify request headers. This is useful for auditing inbound traffic modifications.
+
+```sql+postgres
+select
+  mt.id,
+  mt.enabled,
+  mt.has_conflict,
+  z.name as zone_name
+from
+  cloudflare_managed_transforms mt
+join
+  cloudflare_zone z
+on
+  mt.zone_id = z.id
+where
+  mt.type = 'request_header';
+```
+
+```sql+sqlite
+select
+  mt.id,
+  mt.enabled,
+  mt.has_conflict,
+  z.name as zone_name
+from
+  cloudflare_managed_transforms mt
+join
+  cloudflare_zone z
+on
+  mt.zone_id = z.id
+where
+  mt.type = 'request_header';
+```
+
+### Query all response header transforms
+Retrieves all managed transforms that modify response headers. This is useful for auditing outbound traffic modifications.
+
+```sql+postgres
+select
+  mt.id,
+  mt.enabled,
+  mt.has_conflict,
+  z.name as zone_name
+from
+  cloudflare_managed_transforms mt
+join
+  cloudflare_zone z
+on
+  mt.zone_id = z.id
+where
+  mt.type = 'response_header';
+```
+
+```sql+sqlite
+select
+  mt.id,
+  mt.enabled,
+  mt.has_conflict,
+  z.name as zone_name
+from
+  cloudflare_managed_transforms mt
+join
+  cloudflare_zone z
+on
+  mt.zone_id = z.id
+where
+  mt.type = 'response_header';
+```
+
+### Count managed transforms by type and status
+Provides a summary of managed transforms grouped by type and enabled status. This gives an overview of your transform configuration across all zones.
+
+```sql+postgres
+select
+  type,
+  enabled,
+  count(*) as transform_count
+from
+  cloudflare_managed_transforms
+group by
+  type,
+  enabled
+order by
+  type,
+  enabled;
+```
+
+```sql+sqlite
+select
+  type,
+  enabled,
+  count(*) as transform_count
+from
+  cloudflare_managed_transforms
+group by
+  type,
+  enabled
+order by
+  type,
+  enabled;


### PR DESCRIPTION
# Example query results

<details>
  <summary>Results</summary>

```
SELECT 
  zone_id, 
  id, 
  type, 
  enabled, 
  has_conflict, 
  conflicts_with 
FROM 
  cloudflare_managed_transforms

+----------------------------------+----------------------------------------+-----------------+---------+--------------+--------------------------------+
| zone_id                          | id                                     | type            | enabled | has_conflict | conflicts_with                 |
+----------------------------------+----------------------------------------+-----------------+---------+--------------+--------------------------------+
| aaa111bbb222ccc333ddd444eee555ff | add_security_headers                   | response_header | false   | false        | <null>                         |
| aaa111bbb222ccc333ddd444eee555ff | remove_x-powered-by_header             | response_header | false   | false        | <null>                         |
| aaa111bbb222ccc333ddd444eee555ff | add_true_client_ip_headers             | request_header  | false   | false        | ["remove_visitor_ip_headers"]  |
| aaa111bbb222ccc333ddd444eee555ff | remove_visitor_ip_headers              | request_header  | false   | false        | ["add_true_client_ip_headers"] |
| aaa111bbb222ccc333ddd444eee555ff | add_visitor_location_headers           | request_header  | false   | false        | <null>                         |
| aaa111bbb222ccc333ddd444eee555ff | add_client_certificate_headers         | request_header  | false   | false        | <null>                         |
| aaa111bbb222ccc333ddd444eee555ff | add_waf_credential_check_status_header | request_header  | false   | false        | <null>                         |
| bbb222ccc333ddd444eee555fff666gg | add_security_headers                   | response_header | true    | false        | <null>                         |
| bbb222ccc333ddd444eee555fff666gg | remove_x-powered-by_header             | response_header | true    | false        | <null>                         |
| bbb222ccc333ddd444eee555fff666gg | remove_visitor_ip_headers              | request_header  | false   | true         | ["add_true_client_ip_headers"] |
| bbb222ccc333ddd444eee555fff666gg | add_waf_credential_check_status_header | request_header  | false   | false        | <null>                         |
| bbb222ccc333ddd444eee555fff666gg | add_client_certificate_headers         | request_header  | false   | false        | <null>                         |
| bbb222ccc333ddd444eee555fff666gg | add_visitor_location_headers           | request_header  | false   | false        | <null>                         |
| bbb222ccc333ddd444eee555fff666gg | add_true_client_ip_headers             | request_header  | true    | false        | ["remove_visitor_ip_headers"]  |
| ccc333ddd444eee555fff666ggg777hh | add_client_certificate_headers         | request_header  | false   | false        | <null>                         |
| ccc333ddd444eee555fff666ggg777hh | add_security_headers                   | response_header | false   | false        | <null>                         |
| ccc333ddd444eee555fff666ggg777hh | remove_visitor_ip_headers              | request_header  | false   | false        | <null>                         |
| ccc333ddd444eee555fff666ggg777hh | add_visitor_location_headers           | request_header  | false   | false        | <null>                         |
| ccc333ddd444eee555fff666ggg777hh | remove_x-powered-by_header             | response_header | false   | false        | <null>                         |
| ccc333ddd444eee555fff666ggg777hh | add_waf_credential_check_status_header | request_header  | false   | false        | <null>                         |
+----------------------------------+----------------------------------------+-----------------+---------+--------------+--------------------------------+
```

</details>
