### PR TITLE
feat: add subscription column to cloudflare_zone table

### DIFF
--- a/cloudflare/table_cloudflare_zone.go
+++ b/cloudflare/table_cloudflare_zone.go
@@ -2,6 +2,8 @@ package cloudflare
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go/v4"
@@ -49,8 +51,9 @@ func tableCloudflareZone(ctx context.Context) *plugin.Table {
 			{Name: "paused", Type: proto.ColumnType_BOOL, Description: "Indicates if the zone is only using Cloudflare DNS services. A true value means the zone will not receive security or performance benefits."},
 			{Name: "permissions", Type: proto.ColumnType_JSON, Description: "Available permissions on the zone for the current user requesting the item.", Transform: transform.FromP(getExtraFieldPermissionsFromAPIresponse, "permissions")},
 			{Name: "settings", Type: proto.ColumnType_JSON, Description: "[DEPRECATED] Simple key value map of zone settings like advanced_ddos = on. Use cloudflare_zone_setting table instead."},
-			{Name: "plan", Type: proto.ColumnType_JSON, Hydrate: getZonePlan, Transform: transform.FromValue(), Description: "Current plan associated with the zone."},
+			{Name: "plan", Type: proto.ColumnType_JSON, Hydrate: getZonePlan, Transform: transform.FromValue(), Description: "Rate plans available for the zone to switch to. Not the current plan - use 'subscription' instead. See #198."},
 			{Name: "plan_pending", Type: proto.ColumnType_JSON, Description: "[DEPRECATED] Pending plan change associated with the zone."},
+			{Name: "subscription", Type: proto.ColumnType_JSON, Hydrate: getZoneSubscription, Transform: transform.FromValue(), Description: "The zone's current subscription, including its active rate plan."},
 			{Name: "status", Type: proto.ColumnType_STRING, Description: "Status of the zone."},
 			{Name: "type", Type: proto.ColumnType_STRING, Description: "A full zone implies that DNS is hosted with Cloudflare. A partial zone is typically a partner-hosted zone or a CNAME setup."},
 			{Name: "vanity_name_servers", Type: proto.ColumnType_JSON, Description: "Custom name servers for the zone."},
@@ -157,6 +160,30 @@ func getZonePlan(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 		return nil, err
 	}
 	return plans, nil
+}
+
+func getZoneSubscription(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	conn, err := connectV4(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+	zone := h.Item.(zones.Zone)
+
+	subscription, err := conn.Zones.Subscriptions.Get(ctx, zone.ID)
+	if err != nil {
+		// No active subscription for this zone.
+		var apiErr *cloudflare.Error
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+		logger.Error("cloudflare_zone.getZoneSubscription", "API error", err)
+		return nil, err
+	}
+	if subscription == nil {
+		return nil, nil
+	}
+	return *subscription, nil
 }
 
 func getSmartTieredCache(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/docs/tables/cloudflare_zone.md
+++ b/docs/tables/cloudflare_zone.md
@@ -111,3 +111,24 @@ select
 from
   cloudflare_zone;
 ```
+
+### Get the rate plan each zone is subscribed to
+Explore each zone's active subscription to see which rate plan it's currently on.
+
+```sql+postgres
+select
+  name,
+  subscription -> 'rate_plan' ->> 'id' as plan_id,
+  subscription -> 'rate_plan' ->> 'public_name' as plan_name
+from
+  cloudflare_zone;
+```
+
+```sql+sqlite
+select
+  name,
+  json_extract(subscription, '$.rate_plan.id') as plan_id,
+  json_extract(subscription, '$.rate_plan.public_name') as plan_name
+from
+  cloudflare_zone;
+```


### PR DESCRIPTION
## Summary

The `plan` column on `cloudflare_zone` returns rate plans the zone is *eligible to switch to* (via `/zones/{id}/available_plans`), not the plan it's actually subscribed to. In practice `is_subscribed` comes back `false` for every entry, including the active plan — see #198.

This PR adds a `subscription` column that queries the zone's actual subscription endpoint (`/zones/{id}/subscription`) instead, giving a reliable way to read a zone's current rate plan.

## Changes

- Added `subscription` column + `getZoneSubscription` hydrate to `cloudflare_zone`.
- Zones with no active subscription resource (HTTP 404, Cloudflare error 1207) return `null` instead of erroring the row.
- Updated `plan`'s description to point at `subscription` for the current plan.
- Added a doc example.

# Example query results

<details>
  <summary>Results</summary>

```
select
  name,
  subscription -> 'rate_plan' ->> 'id' as plan_id,
  subscription -> 'rate_plan' ->> 'public_name' as plan_name
from
  cloudflare_zone;

+------------------------+------------+---------------------------+
| name                   | plan_id    | plan_name                 |
+------------------------+------------+---------------------------+
| shop.example.com       | <null>     | <null>                    |
| blog.example.org       | <null>     | <null>                    |
| free-demo.example.dev  | free       | Cloudflare Free Plan      |
| test.sample-corp.com   | free       | Cloudflare Free Plan      |
| cdn.sample-corp.com    | business   | Cloudflare Business Plan  |
| app.exampleco.io       | enterprise | Enterprise                |
| portal.exampleco.io    | enterprise | Enterprise                |
+------------------------+------------+---------------------------+
```
Zones with <null> simply have no active subscription resource.

</details>
